### PR TITLE
Gestion des réponses CAS XML #184

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Par exemple si `appli.data_dir=/etc/eStage/uploads` on aura :
      |_/signatures
 ```
 
+## CAS
+
+Par défaut, l'application attend du serveur CAS une réponse au format JSON. Si le serveur CAS répond au format XML,
+il faut ajouter la ligne suivante au fichier `estage.properties` :
+```properties
+cas.response_type=xml
+```
+
 ## Signature électronique (optionnel)
 
 La signature électronique est activée si au moins une des configuration ci-dessous est paramétrée. Si plusieurs solutions configurées, Docaposte prendra le dessus.

--- a/src/main/java/org/esup_portail/esup_stage/bootstrap/AppConfig.java
+++ b/src/main/java/org/esup_portail/esup_stage/bootstrap/AppConfig.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Properties;
 
 public class AppConfig {
+    private String casResponseType;
     private String casUrlLogin;
     private String casUrlLogout;
     private String casUrlService;
@@ -47,6 +48,14 @@ public class AppConfig {
     private String webhookSignatureToken;
     private String esupSignatureUri;
     private AppSignatureEnum appSignatureEnabled;
+
+    public String getCasResponseType() {
+        return casResponseType;
+    }
+
+    public void setCasResponseType(String casResponseType) {
+        this.casResponseType = casResponseType;
+    }
 
     public String getCasUrlLogin() {
         return casUrlLogin;
@@ -353,6 +362,11 @@ public class AppConfig {
     }
 
     public void initProperties(Properties props, String prefixeProps) {
+        if (props.containsKey("cas.response_type") && !Strings.isEmpty(props.getProperty("cas.response_type"))) {
+            this.casResponseType = props.getProperty("cas.response_type");
+        } else {
+            this.casResponseType = "json";
+        }
         this.casUrlLogout = props.getProperty("cas.url.logout");
         this.casUrlLogin = props.getProperty("cas.url.login");
         this.casUrlService = props.getProperty("cas.url.service");
@@ -435,6 +449,7 @@ public class AppConfig {
     @Override
     public String toString() {
         return "AppConfig{" +
+                ", casResponseType='" + casResponseType + "'" +
                 ", casUrlLogin='" + casUrlLogin + "'" +
                 ", casUrlLogout='" + casUrlLogout + "'" +
                 ", casUrlService='" + casUrlService + "'" +

--- a/src/main/java/org/esup_portail/esup_stage/config/SecurityConfiguration.java
+++ b/src/main/java/org/esup_portail/esup_stage/config/SecurityConfiguration.java
@@ -4,6 +4,7 @@ import org.esup_portail.esup_stage.bootstrap.ApplicationBootstrap;
 import org.esup_portail.esup_stage.security.userdetails.CasUserDetailsServiceImpl;
 import org.jasig.cas.client.session.SingleSignOutFilter;
 import org.jasig.cas.client.validation.TicketValidator;
+import org.jasig.cas.client.validation.Cas20ServiceTicketValidator;
 import org.jasig.cas.client.validation.json.Cas30JsonServiceTicketValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -49,6 +50,10 @@ public class SecurityConfiguration {
 
     @Bean
     public TicketValidator ticketValidator() {
+        
+        if (applicationBootstrap.getAppConfig().getCasResponseType().equals("xml")) {
+            return new Cas20ServiceTicketValidator(applicationBootstrap.getAppConfig().getCasUrlService());
+        }
         return new Cas30JsonServiceTicketValidator(applicationBootstrap.getAppConfig().getCasUrlService());
     }
 


### PR DESCRIPTION
Ce commit permet à ESUP-Stage de pouvoir communiquer avec un serveur CAS qui répond en XML.
Pour activer ce comportement, il faut ajouter la ligne cas.response_type=xml dans le fichier estage.properties.
Si cette ligne n'apparaît pas, ou qu'elle a une autre valeur, le comportement par défaut (json) est appliqué.