### PR TITLE
Permettre d'utiliser les built-ins Freemarker dans les templates #201

### DIFF
--- a/src/main/java/org/esup_portail/esup_stage/controller/TemplateConventionController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/TemplateConventionController.java
@@ -145,7 +145,7 @@ public class TemplateConventionController {
     }
 
     private void checkChamp(List<ParamConvention> champs, String champ) {
-        if (champs.stream().noneMatch(c -> c.getCode().equals(champ))) {
+        if (champs.stream().noneMatch(c -> c.getCode().equals(champ.split("\\?")[0]))) {
             throw new AppException(HttpStatus.BAD_REQUEST, "Le champ personnalisé ${" + champ + "} n'existe pas");
         }
     }


### PR DESCRIPTION
Ce commit permet d'utilisation les built-ins Freemarker. Par exemple, on peut écrire `${etudiant.nom?upper_case}` pour afficher le nom de l'étudiant en majuscules.

Voir https://freemarker.apache.org/docs/dgui_quickstart_template.html#autoid_7