### PR TITLE
Page d'erreur personnalisé

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,14 @@
 			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>nz.net.ultraq.thymeleaf</groupId>
+			<artifactId>thymeleaf-layout-dialect</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-ui</artifactId>
 			<version>1.7.0</version>

--- a/src/main/java/org/esup_portail/esup_stage/config/SecurityConfiguration.java
+++ b/src/main/java/org/esup_portail/esup_stage/config/SecurityConfiguration.java
@@ -97,7 +97,7 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain filterChainPrivate(HttpSecurity http) throws Exception {
         http.authorizeRequests()
-                .antMatchers("/login/cas", "/api/version").permitAll()
+                .antMatchers("/login/cas", "/api/version", "/error", "/theme.css").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .exceptionHandling().authenticationEntryPoint(casEntryPoint())

--- a/src/main/java/org/esup_portail/esup_stage/config/WebMcvConfiguration.java
+++ b/src/main/java/org/esup_portail/esup_stage/config/WebMcvConfiguration.java
@@ -1,7 +1,9 @@
 package org.esup_portail.esup_stage.config;
 
+import nz.net.ultraq.thymeleaf.LayoutDialect;
 import org.esup_portail.esup_stage.controller.ApiController;
 import org.esup_portail.esup_stage.controller.apipublic.ApiPublicController;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.HandlerTypePredicate;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
@@ -29,5 +31,10 @@ public class WebMcvConfiguration implements WebMvcConfigurer {
     public void configurePathMatch(PathMatchConfigurer configurer) {
         configurer.addPathPrefix("/api", HandlerTypePredicate.forAnnotation(ApiController.class));
         configurer.addPathPrefix("/public/api", HandlerTypePredicate.forAnnotation(ApiPublicController.class));
+    }
+
+    @Bean
+    public LayoutDialect layoutDialect() {
+        return new LayoutDialect();
     }
 }

--- a/src/main/java/org/esup_portail/esup_stage/controller/CustomErrorController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/CustomErrorController.java
@@ -1,0 +1,35 @@
+package org.esup_portail.esup_stage.controller;
+
+import org.esup_portail.esup_stage.dto.ConfigThemeDto;
+import org.esup_portail.esup_stage.service.AppConfigService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletRequest;
+
+@Controller
+public class CustomErrorController implements ErrorController {
+
+    @Autowired
+    AppConfigService appConfigService;
+
+    @RequestMapping("/error")
+    public String handleError(HttpServletRequest request, ModelMap model) {
+        ConfigThemeDto configTheme = appConfigService.getConfigTheme();
+        model.addAttribute("favicon", "data:" + configTheme.getFavicon().getContentType() + ";base64," + configTheme.getFavicon().getBase64());
+
+        Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        if (status != null) {
+            int statusCode = Integer.parseInt(status.toString());
+            if (statusCode == HttpStatus.UNAUTHORIZED.value()) {
+                return "error-401";
+            }
+        }
+        return "error";
+    }
+}

--- a/src/main/resources-filtered/application.properties
+++ b/src/main/resources-filtered/application.properties
@@ -15,6 +15,9 @@ application.configfilepath=${application.configfilepath}
 # proprietes fixes de spring
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+server.error.whitelabel.enabled=false
+server.error.path=/error
+spring.mvc.view.suffix=.html
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # proprietes openapi

--- a/src/main/resources/templates/error-401.html
+++ b/src/main/resources/templates/error-401.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="fr" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{error.html}">
+<head>
+</head>
+<body>
+<section layout:fragment="error-content">
+  <div>Vous n'avez pas les autorisations nécessaires pour accéder à cette application. Veuillez contacter un administrateur ou un gestionnaire de stage.</div>
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="fr" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"  xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="utf-8">
+  <title>ESUP - Stage</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link id="app-favicon" rel="icon" type="image/x-icon" th:href="${favicon}">
+  <link id="theme" rel="stylesheet" href="/theme.css">
+
+  <style>
+    body {
+      margin: auto;
+      font-family: var(--fontFamily);
+    }
+
+    header {
+      font-size: 2.5em;
+      width: 100%;
+      color: white;
+      background: var(--primaryColor);
+      text-align: center;
+      height: 100px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .error-message {
+      width: 90%;
+      text-align: center;
+      margin: 15% auto 0;
+      font-weight: bold;
+      font-size: x-large;
+    }
+  </style>
+</head>
+<body>
+<header>
+  <div>ESUP-Stage</div>
+</header>
+<div class="error-message">
+  <section layout:fragment="error-content">
+    <div>Une erreur technique est survenue. Veuillez contacter un administrateur.</div>
+  </section>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Création d'une page spécifique à l'affiche d'un message d'erreur quand l'utilisation ne dispose pas des autorisations nécessaires pour accéder à l'application. Cette page remplace la page d'erreur Apache affichée par défaut. Cette page induisait en erreur en laissant penser que l'application avait planté.