### PR TITLE
bug #7483 - permet  aux étudiants et aux gestionnaires d'accéder au suivi des signatures

### DIFF
--- a/src/frontend/src/app/components/convention/signature-electronique/signature-electronique-view/signature-electronique-view.component.html
+++ b/src/frontend/src/app/components/convention/signature-electronique/signature-electronique-view/signature-electronique-view.component.html
@@ -26,7 +26,7 @@
           Docaposte et ESUP-Signature : les informations de signature sont mises à jour automatiquement tous les jours à 1h.<br/>
           Solutions externes : les informations de signature sont mis à jour automatiquement via webhook.<br/>
           L'actualisation des données n'est possible que toutes les 30 minutes.
-            <div class="mt-2 text-center" *ngIf="isGestionnaire">
+            <div class="mt-2 text-center">
                 <button mat-button mat-flat-button color="primary" (click)="updateSignatureInfos()" [disabled]="isActualisationActif()">
                   Mettre à jour les informations et récupérer le document signé
                 </button>

--- a/src/frontend/src/app/components/convention/signature-electronique/signature-electronique-view/signature-electronique-view.component.ts
+++ b/src/frontend/src/app/components/convention/signature-electronique/signature-electronique-view/signature-electronique-view.component.ts
@@ -11,7 +11,6 @@ export class SignatureElectroniqueViewComponent implements OnInit {
 
   @Input() avenant!: any;
   @Input() convention!: any;
-  @Input() isGestionnaire: any;
   @Input() isMobile: any;
   @Input() profils: any[] = [];
 

--- a/src/frontend/src/app/components/convention/signature-electronique/signature-electronique.component.html
+++ b/src/frontend/src/app/components/convention/signature-electronique/signature-electronique.component.html
@@ -27,7 +27,7 @@
         Docaposte et ESUP-Signature : les informations de signature sont mises à jour automatiquement tous les jours à 1h.<br/>
         Solutions externes : les informations de signature sont mis à jour automatiquement via webhook.<br/>
         L'actualisation des données n'est possible que toutes les 30 minutes.
-        <div class="mt-2 text-center" *ngIf="isGestionnaire">
+        <div class="mt-2 text-center">
           <button mat-button mat-flat-button color="primary" (click)="updateSignatureInfos()" [disabled]="isActualisationActif()">
             Mettre à jour les informations et récupérer le document signé
           </button>
@@ -81,7 +81,6 @@
 
 <mat-card *ngFor="let avenant of convention.avenants">
   <app-signature-electronique-view *ngIf="profils.length > 0"
-                                   [isGestionnaire]="isGestionnaire"
                                    [isMobile]="isMobile"
                                    [profils]="profils"
                                    [avenant]="avenant"

--- a/src/frontend/src/app/components/convention/signature-electronique/signature-electronique.component.ts
+++ b/src/frontend/src/app/components/convention/signature-electronique/signature-electronique.component.ts
@@ -20,7 +20,7 @@ export class SignatureElectroniqueComponent implements OnInit {
   profils: any[] = [];
   data: any[] = [];
   isGestionnaire = false;
-  signatureType: string;
+  signatureType: string | undefined;
 
   constructor(
     private technicalService: TechnicalService,

--- a/src/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/src/frontend/src/app/components/dashboard/dashboard.component.html
@@ -2,8 +2,7 @@
   <mat-card-content>
     <div class="row">
       <div class="col-md-6 col-sm-12">
-        <h6>Convention(s) en attente de validation : <span class="text-title"
-                                                           *ngIf="nbConventionsEnAttente !== undefined">{{nbConventionsEnAttente}} trouvée(s)</span></h6>
+        <h6>Convention(s) en attente de validation : <span class="text-title" *ngIf="nbConventionsEnAttente !== undefined">{{nbConventionsEnAttente}} trouvée(s)</span></h6>
       </div>
       <div class="col-md-6 col-sm-12 text-right">
         <mat-form-field>

--- a/src/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/src/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -361,7 +361,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       { id: 'enseignant', libelle: 'Enseignant', specific: true },
       { id: 'avenant', libelle: 'Avenant', type: 'boolean', specific: true },
       { id: 'etatValidation', libelle: 'État de validation de la convention', type: 'list', options: this.validationsOptions, keyLibelle: 'libelle', keyId: 'id', value: [], specific: true },
-      { id: 'annee', libelle: 'Année', type: 'list', options: [], keyLibelle: 'libelle', keyId: 'libelle', value: [] },
+      { id: 'annee', libelle: 'Année', type: 'annee', options: [], keyLibelle: 'libelle', keyId: 'libelle', value: [] },
     ];
 
     this.exportColumns = {

--- a/src/frontend/src/app/components/table/table.component.html
+++ b/src/frontend/src/app/components/table/table.component.html
@@ -37,6 +37,11 @@
                     <mat-option [value]="'N'">Non</mat-option>
                   </mat-select>
                 </ng-container>
+                <ng-container *ngSwitchCase="'annee'">
+                  <mat-select [name]="filter.id" [(ngModel)]="filterValues[filter.id].value" (ngModelChange)="update()">
+                    <mat-option *ngFor="let option of filter.options" [value]="option[filter.keyId]" [matTooltip]="filter.infoBulleCentre ? option[filter.keyLibelle] : ''">{{option[filter.keyLibelle]|| 'Valeur indisponible' }}</mat-option>
+                  </mat-select>
+                </ng-container>
                 <ng-container *ngSwitchCase="'date'">
                   <input matInput [name]="filter.id" [matDatepicker]="datepicker" [(ngModel)]="filterValues[filter.id].value" (ngModelChange)="update()" />
                 </ng-container>

--- a/src/frontend/src/app/components/table/table.component.ts
+++ b/src/frontend/src/app/components/table/table.component.ts
@@ -330,7 +330,12 @@ export class TableComponent implements OnInit, AfterContentInit, OnChanges {
                 codeUniversite: f[key].value.codeUniversite,
               };
             }
-          } else {
+          }else if (key === 'annee') {
+            if (Array.isArray(f[key].value)) {
+              f[key].value = String(f[key].value[0]);
+            }
+          }
+          else {
             // Traitement normal pour les autres listes
             if (Array.isArray(f[key].value)) {
               f[key].value = f[key].value

--- a/src/main/java/org/esup_portail/esup_stage/controller/CentreGestionController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/CentreGestionController.java
@@ -157,7 +157,7 @@ public class CentreGestionController {
     }
 
     @GetMapping("/{id}")
-    @Secure(fonctions = {AppFonctionEnum.PARAM_CENTRE}, droits = {DroitEnum.LECTURE})
+    @Secure
     public CentreGestion getById(@PathVariable("id") int id) {
         CentreGestion centreGestion = centreGestionJpaRepository.findById(id);
         if (centreGestion == null) {

--- a/src/main/java/org/esup_portail/esup_stage/service/signature/SignatureService.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/signature/SignatureService.java
@@ -159,7 +159,7 @@ public class SignatureService {
         if (appSignature == null) {
             throw new AppException(HttpStatus.BAD_REQUEST, "La signature électronique n'est pas configurée");
         }
-        if (idsListDto.getIds().size() == 0) {
+        if (idsListDto.getIds().isEmpty()) {
             throw new AppException(HttpStatus.BAD_REQUEST, "La liste est vide");
         }
         int count = 0;


### PR DESCRIPTION
J'ai supprimé les protections qui empêchaient les étudiants et les gestionnaires d'accéder à la page de suivi des signatures. J'en ai également profité pour corriger le filtre d'année sur le tableau de bord de la vue étudiant, qui ne fonctionnait plus.