### PR TITLE
Trier les inscriptions par année et afficher l'année avant l'étape

### DIFF
--- a/src/frontend/src/app/components/convention/etudiant/etudiant.component.html
+++ b/src/frontend/src/app/components/convention/etudiant/etudiant.component.html
@@ -168,7 +168,7 @@
                     <mat-form-field class="col-sm-12 mb-2" appearance="fill">
                       <mat-label>Formation</mat-label>
                       <mat-select formControlName="inscription" required>
-                        <mat-option *ngFor="let inscription of inscriptions" [value]="inscription">{{inscription.etapeInscription.codeEtp + ' - ' + inscription.etapeInscription.libWebVet + ' ' + inscription.annee + '/' + (+inscription.annee + 1)}}<span class="option-composante">({{inscription.etapeInscription.codeComposante}})</span></mat-option>
+                        <mat-option *ngFor="let inscription of inscriptions" [value]="inscription">{{inscription.annee + '/' + (+inscription.annee + 1) + ': ' + inscription.etapeInscription.codeEtp + ' - ' + inscription.etapeInscription.libWebVet}}<span class="option-composante">({{inscription.etapeInscription.codeComposante}})</span></mat-option>
                       </mat-select>
                       <mat-error><app-form-error [field]="formConvention.get('inscription')"></app-form-error></mat-error>
                     </mat-form-field>

--- a/src/frontend/src/app/components/convention/etudiant/etudiant.component.ts
+++ b/src/frontend/src/app/components/convention/etudiant/etudiant.component.ts
@@ -239,6 +239,7 @@ export class EtudiantComponent implements OnInit, OnChanges {
     });
     this.etudiantService.getApogeeInscriptions(row.codEtu, this.convention ? this.convention.annee : null).subscribe((response: any) => {
       this.inscriptions = response;
+      this.inscriptions.sort((a,b) => a.annee < b.annee ? 1 : -1);
       if (this.inscriptions.length === 1) {
         this.formConvention.get('inscription')?.setValue(this.inscriptions[0]);
       }


### PR DESCRIPTION
Bonjour,

lorsqu'un étudiant est inscrit à plusieurs formations ou est susceptible de créer une convention sur l'année en cours ou l'année à venir, la liste des formations ne permet pas de choisir avec précision l'inscription souhaitée.

Cette PR permet de trier les formations par année lorsqu'un étudiant a plusieurs inscriptions, et affiche l'année avant la formation :

<img width="793" height="268" alt="feature-annee-etape" src="https://github.com/user-attachments/assets/9b0ebceb-7d2c-4e85-aa52-657e5070fda2" />
