### PR TITLE
Faire apparaître la France en premier la liste déroulante des pays

### DIFF
--- a/src/main/java/org/esup_portail/esup_stage/controller/PaysController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/PaysController.java
@@ -42,7 +42,11 @@ public class PaysController {
         List<PaysDto> paysDtoList = new ArrayList<>();
         for (Pays pays : paginatedResponsePays.getData()) {
             PaysDto dto = new PaysDto(pays.getId(), pays.getLib(), pays.getTemEnServPays());
-            paysDtoList.add(dto);
+            if (pays.getIso2().equals("FR")) {
+                paysDtoList.add(0, dto);
+            } else {
+                paysDtoList.add(dto);
+            }
         }
 
         paginatedResponsePaysDto.setData(paysDtoList);


### PR DESCRIPTION
Bonjour,

cette PR permet d'afficher la France en premier dans les listes déroulantes "Pays" (notamment lors de la création d'un établissement d'accueil) :

<img width="386" height="340" alt="france-premier-liste" src="https://github.com/user-attachments/assets/099c06e0-733f-4112-9a89-5c1adfcea5e1" />
