### PR TITLE
Ajouter une icône lorsqu'une convention n'a pas été envoyée en signature

### DIFF
--- a/src/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/src/frontend/src/app/components/dashboard/dashboard.component.html
@@ -77,6 +77,9 @@
          [ngClass]="getValidationIconStatus(row)"
          [matTooltip]="getValidationTooltip(row)">
       </i>
+      <i *ngIf="!row.dateEnvoiSignature" class="fa-solid fa-xmark"
+        [matTooltip]="'Pas envoyée en signature'">
+      </i>
     </td>
   </ng-container>
   <ng-container matColumnDef="id">
@@ -124,8 +127,11 @@
          [class.activate]="row.validationConvention"
          matTooltip="{{row.validationConvention ? validationLibelles.validationConvention + ' effectuée' : 'en attente ' + validationLibelles.validationConvention}}"></i>
       <i *ngIf="row.dateEnvoiSignature" class="fa-solid fa-signature"
-         [ngClass]="getValidationIconStatus(row)"
-         [matTooltip]="getValidationTooltip(row)">
+        [ngClass]="getValidationIconStatus(row)"
+        [matTooltip]="getValidationTooltip(row)">
+      </i>
+      <i *ngIf="!row.dateEnvoiSignature" class="fa-solid fa-xmark"
+        [matTooltip]="'Pas envoyée en signature'">
       </i>
     </td>
   </ng-container>
@@ -214,6 +220,9 @@
         <i *ngIf="row.dateEnvoiSignature" class="fa-solid fa-signature"
            [ngClass]="getValidationIconStatus(row)"
            [matTooltip]="getValidationTooltip(row)">
+        </i>
+        <i *ngIf="!row.dateEnvoiSignature" class="fa-solid fa-xmark"
+          [matTooltip]="'Pas envoyée en signature'">
         </i>
       </td>
     </tr>


### PR DESCRIPTION
Bonjour,

il me semble peu naturel de différencier une convention qui a été envoyée en signature mais qui n'a aucune signature (icône signature rouge) d'une convention qui n'a pas été envoyée en signature (pas d'icône).

Afficher une icône spécifique lorsqu'une convention n'a pas été envoyée en signature me semble plus explicite que ne pas afficher d'icône. 

Cette PR permet d'afficher une icône spécifique qui indique qu'une convention n'a pas  :

<img width="181" height="77" alt="icone-non-envoyee" src="https://github.com/user-attachments/assets/2bdbad99-fd29-43c0-89e0-eb521374782b" />
