### PR TITLE
Alerter le gestionnaire en cas d'écrasement d'un envoi en signature

### DIFF
--- a/src/frontend/src/app/components/convention/validation/validation.component.html
+++ b/src/frontend/src/app/components/convention/validation/validation.component.html
@@ -41,7 +41,8 @@
     <div class="row mt-3" *ngIf="signatureEnabled && validee">
       <div class="col text-right">
         <span (confirm)="controleSignatureElectronique()" [confirmMessage]="'ALERTE_SIGNATURE'|contenu">
-          <button mat-button mat-flat-button color="primary">Envoi pour signature électronique</button>
+          <button mat-button mat-flat-button color="primary" *ngIf="!convention.dateEnvoiSignature">Envoi pour signature électronique</button>
+          <button mat-button mat-flat-button color="accent" *ngIf="!!convention.dateEnvoiSignature">⚠️Écraser l'envoi précédent et renvoyer en signature électronique</button>
         </span>
       </div>
     </div>


### PR DESCRIPTION
Bonjour,

si l'on utilise ESUP-Signature, lorsqu'on envoie une nouvelle demande de signature, l'ancienne demande est supprimée. Le gestionnaire ne sait pas, forcément, au moment où il clique sur le bouton "Envoi pour signature électronique", que la convention a déjà été envoyée. Cela peut résulter dans des suppressions involontaires de demande de signature.

Cette PR permet d'afficher un texte et une couleur différentes si la convention a déjà été envoyée en signature :

<img width="484" height="45" alt="alerte-envoi-signature" src="https://github.com/user-attachments/assets/27999d5b-3df9-4a1a-b76e-b9ea4b3c3781" />

La couleur utilisée est la couleur secondaire du thème.
