### PR TITLE
Correction issue #409 et modification d'un texte en contenu

### DIFF
--- a/src/frontend/src/app/components/centre-gestion/signature-electronique/signature-electronique.component.html
+++ b/src/frontend/src/app/components/centre-gestion/signature-electronique/signature-electronique.component.html
@@ -11,7 +11,7 @@
           <mat-error><app-form-error [field]="form.get('circuitSignature')"></app-form-error></mat-error>
         </mat-form-field>
         <div class="col-12">
-          <mat-checkbox formControlName="envoiDocumentSigne">Activer l'envoi du document signé</mat-checkbox>
+          <mat-checkbox formControlName="envoiDocumentSigne">{{"MESSAGE_ENVOI_DOCUMENT_SIGNE_DOCAPOSTE" | contenu}}</mat-checkbox>
         </div>
         <div class="col-12">
           <div class="text-title">Ordre de signature</div>

--- a/src/main/java/org/esup_portail/esup_stage/service/signature/SignatureService.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/signature/SignatureService.java
@@ -544,16 +544,18 @@ public class SignatureService {
                 log.info("Convention signée complètement. ID = {}", convention.getId());
                 ConfigAlerteMailDto configAlerteMailDto = appConfigService.getConfigAlerteMail();
                 Utilisateur utilisateur = convention.getLoginEnvoiSignature() != null? utilisateurJpaRepository.findByLogin(convention.getLoginEnvoiSignature()): utilisateurJpaRepository.findOneByLogin(convention.getLoginValidation()) ;
-                if(convention.getCentreGestion().isOnlyMailCentreGestion()){
-                    //si le paramètre OnlyMailCentreGestion est activé on envoi à l'adresse du centre de gestion
-                    mailerService.sendAlerteValidation(convention.getCentreGestion().getMail() , convention, null, utilisateur, "CONVENTION_SIGNEE");
-                }else if(configAlerteMailDto.getAlerteGestionnaire().isConventionSignee()){
-                    // sinon on envoi le mail aux gestionnaires
-                    List<PersonnelCentreGestion> personnels = convention.getCentreGestion().getPersonnels();
-                    assert personnels != null;
-                    for (PersonnelCentreGestion personnel : personnels) {
-                        if (mailerService.isAlerteActif(personnel, "CONVENTION_SIGNEE")) {
-                            mailerService.sendAlerteValidation(personnel.getMail(), convention, null, utilisateur, "CONVENTION_SIGNEE");
+                if(configAlerteMailDto.getAlerteGestionnaire().isConventionSignee()){
+                    if(convention.getCentreGestion().isOnlyMailCentreGestion()){
+                        //si le paramètre OnlyMailCentreGestion est activé on envoi à l'adresse du centre de gestion
+                        mailerService.sendAlerteValidation(convention.getCentreGestion().getMail() , convention, null, utilisateur, "CONVENTION_SIGNEE");
+                    }else{
+                        // sinon on envoi le mail aux gestionnaires
+                        List<PersonnelCentreGestion> personnels = convention.getCentreGestion().getPersonnels();
+                        assert personnels != null;
+                        for (PersonnelCentreGestion personnel : personnels) {
+                            if (mailerService.isAlerteActif(personnel, "CONVENTION_SIGNEE")) {
+                                mailerService.sendAlerteValidation(personnel.getMail(), convention, null, utilisateur, "CONVENTION_SIGNEE");
+                            }
                         }
                     }
                 }

--- a/src/main/resources/db/changelog/3.1.7-contenu-envoi-doc-signe.yaml
+++ b/src/main/resources/db/changelog/3.1.7-contenu-envoi-doc-signe.yaml
@@ -1,0 +1,34 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.1.7-contenu-envoi-doc-signe
+      author: thouveno9
+      changes:
+        - insert:
+            columns:
+              - column:
+                  name: codeContenu
+                  value: MESSAGE_ENVOI_DOCUMENT_SIGNE_DOCAPOSTE
+              - column:
+                  name: libelle
+                  valueBoolean: true
+              - column:
+                  name: texte
+                  value: Activer l'envoi du document signé au signataire (Docaposte uniquement)
+              - column:
+                  name: loginCreation
+                  value: liquibase
+              - column:
+                  name: dateCreation
+                  value: now()
+            tableName: Contenu
+  - changeSet:
+      id: 3.1.7-contenu-envoi-doc-signe-update-texte
+      author: thouveno9
+      changes:
+        - update:
+            tableName: Contenu
+            columns:
+              - column:
+                  name: texte
+                  value: "Activer l'envoi du document signé au signataire pour le compte de l'établissement d'accueil"
+            where: "codeContenu = 'MESSAGE_ENVOI_DOCUMENT_SIGNE_DOCAPOSTE'"

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -273,3 +273,6 @@ databaseChangeLog:
   - include:
         file: 3.1.6-contenu-hint-pays-etablissement.yaml
         relativeToChangelogFile: true
+  - include:
+        file: 3.1.7-contenu-envoi-doc-signe.yaml
+        relativeToChangelogFile: true


### PR DESCRIPTION
- Correction du ticket [#409](https://github.com/EsupPortail/esup-stage/issues/409) en modifiant l’ordre des conditions.
- Ajout du texte « Activer l’envoi du document signé » de l’onglet Signature électronique des centres de gestion dans les contenus.