### PR TITLE
bugfix #460 - Conventions en masse : l'année par défaut est déterminée depuis l'année civile

### DIFF
--- a/src/frontend/src/app/components/convention-create-en-masse/selection-groupe-etu/selection-groupe-etu.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/selection-groupe-etu/selection-groupe-etu.component.ts
@@ -31,13 +31,7 @@ export class SelectionGroupeEtuComponent implements OnInit {
   selectedAdd: any[] = [];
   etudiants: any[] = [];
 
-  // Années N-1 / N / N+1
-  currentYear = (new Date()).getFullYear();
-  annees = [
-    { label: (this.currentYear - 1) + '/' + (this.currentYear), value: this.currentYear - 1 },
-    { label: this.currentYear + '/' + (this.currentYear + 1), value: this.currentYear },
-    { label: (this.currentYear + 1) + '/' + (this.currentYear + 2), value: this.currentYear + 1 },
-  ];
+  annees: { label:string, value:number }[] = [];
   ufrList: any[] = [];
   etapeList: any[] = [];
 
@@ -79,7 +73,7 @@ export class SelectionGroupeEtuComponent implements OnInit {
       prenom: [null, []],
       etape: [null, []],
       composante: [null, []],
-      annee: [this.currentYear, []],
+      annee: [null, []],
     });
 
     this.formAddEtudiants.get('etape')?.disable({ emitEvent: false });
@@ -89,6 +83,21 @@ export class SelectionGroupeEtuComponent implements OnInit {
     this.formAddEtudiants.get('composante')?.valueChanges.subscribe((changes) => {
       this.getEtapes(this.formAddEtudiants.get('annee')?.value, changes);
     });
+  }
+
+  // Années N-1 / N / N+1
+  initCurrentYear(anneeEnCours?: string): void {
+    const currentYear:number = anneeEnCours ? Number.parseInt(anneeEnCours) : this.anneeUniversitaire(new Date());
+    this.annees = [
+      { label: (currentYear - 1) + '/' + (currentYear), value: currentYear - 1 },
+      { label: currentYear + '/' + (currentYear + 1), value: currentYear },
+      { label: (currentYear + 1) + '/' + (currentYear + 2), value: currentYear + 1 },
+    ];
+    this.formAddEtudiants.get('annee')?.setValue(currentYear);
+  }
+
+  anneeUniversitaire(now:Date): number {
+    return now.getMonth() > 7 ? now.getFullYear() : now.getFullYear() -1;
   }
 
   getEtapes(annee: string, composante: string): void {
@@ -121,6 +130,13 @@ export class SelectionGroupeEtuComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.conventionService.getListAnnee().subscribe({
+      next: (listAnneeData) => this.initCurrentYear(
+          listAnneeData.find((a:any) => a?.anneeEnCours === true)?.annee
+        ),
+      error: (e) => this.initCurrentYear()
+    });
+
     this.groupeEtudiantColumns = [...this.sharedData.columns];
     this.groupeEtudiantFilters = [...this.sharedData.filters];
     this.columns =  [...this.sharedData.columns];


### PR DESCRIPTION
## Description / Objectif / Motivation / Contexte
<!-- Pourquoi ce changement est-il important ?
    Quel problème résout-il ?
    Veuillez inclure un résumé des modifications et du problème associé.
    Veuillez également inclure la motivation et le contexte pertinent.
    Énumérez toutes les dépendances requises par ce changement.
-->
Dans la gestion des conventions en masse, l'année sélectionnée par défaut est l'année civile et non l'année universitaire.

<!--- Si vous suggérez une nouvelle fonctionnalité ou un changement,
      merci d'ouvrir un ticket (issue) avant -->
Ticket: #460 

## Cas d'acceptance (Comment cela a-t-il été testé ?)
<!-- ou lien https://... vers ticket avec les cas de test
Si vous corrigez un⋅e bogue, il devrait y avoir un ticket
le décrivant avec des étapes pour le reproduire -->

<!--
Veuillez décrire les tests que vous avez effectués pour vérifier vos modifications.
Fournir des instructions pour que nous puissions reproduire.
Veuillez également énumérer tous les détails pertinents de votre configuration de test.
-->
- Scénario:
  - Étant donné qu'on est aujourd'hui entre septembre et décembre,
  - Quand j'ouvre la création de conventions en masse, 
  - Alors l'année sélectionnée par défaut dans _Ajouter des étudiants au groupe_ est l'année universitaire en cours : année/(année+1)

- Scénario:
  - Étant donné qu'on est aujourd'hui entre janvier et août,
  - Quand j'ouvre la création de conventions en masse, 
  - Alors l'année sélectionnée par défaut dans _Ajouter des étudiants au groupe_ est l'année universitaire en cours : (année-1)/année

<!-- Mentionnez s'il y a des tests automatisés pour ce changement 🙏 -->
### Tests automatisés
* aucun
<!-- Joindre des captures d'écran (le cas échéant) -->

## Type

<!--Veuillez supprimer des options qui ne sont pas pertinentes.-->
- 🗹 Correction de bogue (modification non cassante qui résout un problème).
- ~☐ Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).~
- ~☐ Changement cassant (correction qui entraînerait la/une fonctionnalité existante à ne pas fonctionner comme précédemment).~
- ~☐ Changement nécessitant une mise à jour de la documentation utilisateur.~

## Definition du fini

- [ ] Les cas d'acceptance ci-dessus ont été vérifiés.
- [ ] Revue par au moins un⋅e relecteur⋅ice autorisé⋅e.
- ~Documentation(s) mise(s) à jour (utilisateur, technique, commentaires de code compris).~
- ~Si des changements _cassants_ sont introduits, ils sont dûment décrits
et les étapes de montée de version décrites (éventuellement scriptés).~
