### PR TITLE
Retourner une erreur si l'appel à ESUP-Signature échoue

### DIFF
--- a/src/main/java/org/esup_portail/esup_stage/service/signature/SignatureService.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/signature/SignatureService.java
@@ -282,6 +282,7 @@ public class SignatureService {
                 count++;
             }catch(Exception e){
                 logger.error("Une erreur est survenue lors du traitement de la convention {} : {}",id,e);
+                throw e;
             }
 
         }


### PR DESCRIPTION
Actuellement, si un envoi en signature échoue, le seul moyen de s'en rendre compte est qu'il n'y a pas une popup "envoi réussi !" qui apparaît. Il serait bien qu'une popup "erreur technique" apparaisse dans ce cas, car elle sera moins facilement ignorée.

Voir #472 

