### PR TITLE
fix #475 verrouillage globale de la mise à jour automatique

### DIFF
--- a/src/frontend/src/app/components/admin/config-generale/config-generale.component.html
+++ b/src/frontend/src/app/components/admin/config-generale/config-generale.component.html
@@ -297,6 +297,15 @@
               </mat-radio-group>
             </div>
           </div>
+          <div class="row mb-2">
+            <div class="col-md-12">
+              <div class="mb-2" [class.section-disabled]="!isSireneAcitve">Désactiver la mise à jour automatique via l'API Sirene lors de la sélection d'un établissement ?</div>
+              <mat-radio-group formControlName="desactiverMajAutoEtabSelection">
+                <mat-radio-button [disabled]="!isSireneAcitve" [value]="true">Oui</mat-radio-button>
+                <mat-radio-button [disabled]="!isSireneAcitve" [value]="false">Non</mat-radio-button>
+              </mat-radio-group>
+            </div>
+          </div>
           <div class="mt-3" *ngIf="canEdit()">
             <button mat-flat-button color="primary">Valider</button>
           </div>

--- a/src/frontend/src/app/components/admin/config-generale/config-generale.component.html
+++ b/src/frontend/src/app/components/admin/config-generale/config-generale.component.html
@@ -306,6 +306,21 @@
               </mat-radio-group>
             </div>
           </div>
+          <div class="row mb-2">
+            <div class="col-md-12">
+              <div class="mb-2" [class.section-disabled]="!isSireneAcitve">Désactiver la mise à jour automatique via l'API Sirene si l'établissement est en diffusion partielle ?</div>
+              <mat-radio-group formControlName="desactiverMajAutoEtabDiffusionPartiel">
+                <mat-radio-button
+                  [disabled]="!isSireneAcitve || formGenerale.get('desactiverMajAutoEtabSelection')?.value === true"
+                  [value]="true"
+                >Oui</mat-radio-button>
+                <mat-radio-button
+                  [disabled]="!isSireneAcitve || formGenerale.get('desactiverMajAutoEtabSelection')?.value === true"
+                  [value]="false"
+                >Non</mat-radio-button>
+              </mat-radio-group>
+            </div>
+          </div>
           <div class="mt-3" *ngIf="canEdit()">
             <button mat-flat-button color="primary">Valider</button>
           </div>

--- a/src/frontend/src/app/components/admin/config-generale/config-generale.component.ts
+++ b/src/frontend/src/app/components/admin/config-generale/config-generale.component.ts
@@ -80,7 +80,8 @@ export class ConfigGeneraleComponent implements OnInit {
       codeCesure: [null],
       autoriserEtudiantACreerEntrepriseFrance: [null],
       autoriserEtudiantACreerEntrepriseHorsFrance: [null],
-      desactiverMajAutoEtabSelection: [null, [Validators.required]],
+      desactiverMajAutoEtabSelection: [null],
+      desactiverMajAutoEtabDiffusionPartiel: [null],
     });
 
     this.formTheme = this.fb.group({
@@ -98,6 +99,10 @@ export class ConfigGeneraleComponent implements OnInit {
     this.formSignature = this.fb.group({
       supprimerConventionUneFoisSigneEsupSignature: [null, [Validators.required]],
       autoriserModifOrdreSignataireCG:[null,[Validators.required]]
+    });
+
+    this.formGenerale.get('desactiverMajAutoEtabSelection')?.valueChanges.subscribe((value) => {
+      this.syncDiffusionPartielControl(value === true);
     });
   }
 
@@ -138,7 +143,21 @@ export class ConfigGeneraleComponent implements OnInit {
     // Récupération des infos sirene
     this.structureService.getSireneInfo().subscribe((response: any) => {
       this.isSireneAcitve = response.isApiSireneActive;
+      this.syncDiffusionPartielControl(this.formGenerale.get('desactiverMajAutoEtabSelection')?.value === true);
     });
+  }
+
+  private syncDiffusionPartielControl(forceDisable: boolean): void {
+    const control = this.formGenerale.get('desactiverMajAutoEtabDiffusionPartiel');
+    if (!control) return;
+    if (forceDisable) {
+      control.setValue(true, { emitEvent: false });
+      control.disable({ emitEvent: false });
+      return;
+    }
+    if (control.disabled) {
+      control.enable({ emitEvent: false });
+    }
   }
 
   setFormThemeValue(): void {
@@ -163,7 +182,8 @@ export class ConfigGeneraleComponent implements OnInit {
 
   saveGenerale(): void {
     if (this.formGenerale.valid) {
-      this.configService.updateGenerale(this.formGenerale.value).subscribe((response: any) => {
+      const payload = this.formGenerale.getRawValue();
+      this.configService.updateGenerale(payload).subscribe((response: any) => {
         this.configGenerale = response;
         this.messageService.setSuccess('Paramètre d\'éléments généraux modifiés');
       });

--- a/src/frontend/src/app/components/admin/config-generale/config-generale.component.ts
+++ b/src/frontend/src/app/components/admin/config-generale/config-generale.component.ts
@@ -1,12 +1,12 @@
-import {Component, OnInit, ViewContainerRef, WritableSignal} from '@angular/core';
+import {Component, OnInit, WritableSignal} from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { ConfigService } from "../../../services/config.service";
 import { AuthService } from "../../../services/auth.service";
 import { MessageService } from "../../../services/message.service";
-import { CentreGestionService } from "../../../services/centre-gestion.service";
 import { AppFonction } from "../../../constants/app-fonction";
 import { Droit } from "../../../constants/droit";
 import {RoleService} from "../../../services/role.service";
+import {StructureService} from "../../../services/structure.service";
 
 @Component({
   selector: 'app-config-generale',
@@ -56,6 +56,7 @@ export class ConfigGeneraleComponent implements OnInit {
   formSignature: FormGroup;
 
   isEtuAutoriseToCreate!: boolean;
+  isSireneAcitve!: boolean;
 
   constructor(
     private configService: ConfigService,
@@ -63,6 +64,7 @@ export class ConfigGeneraleComponent implements OnInit {
     private authService: AuthService,
     private messageService: MessageService,
     private roleService: RoleService,
+    private structureService: StructureService
   ) {
     this.formGenerale = this.fb.group({
       codeUniversite: [null, [Validators.required]],
@@ -78,6 +80,7 @@ export class ConfigGeneraleComponent implements OnInit {
       codeCesure: [null],
       autoriserEtudiantACreerEntrepriseFrance: [null],
       autoriserEtudiantACreerEntrepriseHorsFrance: [null],
+      desactiverMajAutoEtabSelection: [null, [Validators.required]],
     });
 
     this.formTheme = this.fb.group({
@@ -130,6 +133,11 @@ export class ConfigGeneraleComponent implements OnInit {
     this.configService.getConfigSignature().subscribe((response: any) => {
       this.configSignature = response;
       this.formSignature.patchValue(this.configSignature);
+    });
+
+    // Récupération des infos sirene
+    this.structureService.getSireneInfo().subscribe((response: any) => {
+      this.isSireneAcitve = response.isApiSireneActive;
     });
   }
 

--- a/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.html
+++ b/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.html
@@ -209,6 +209,7 @@
           <span class="sync-radio-label">Synchronisation automatique</span>
           <mat-radio-group
             [value]="etab.verrouillageSynchroStructureSirene ? 'non' : 'oui'"
+            [disabled]="isMajAutoDisabled"
             (change)="toggleVerrouillage()"
             aria-label="Synchronisation automatique">
             <mat-radio-button value="oui">Oui</mat-radio-button>
@@ -219,7 +220,7 @@
 
       <!-- Mise à jour automatique -->
       <div class="slot" *ngIf="canUpdateFromApi()">
-        <button type="button" mat-button mat-stroked-button color="primary" class="mr-2" [disabled]="autoUpdating || etab.verrouillageSynchroStructureSirene" (click)="autoUpdateFromApi()"
+        <button type="button" mat-button mat-stroked-button color="primary" class="mr-2" [disabled]="autoUpdating" (click)="autoUpdateFromApi()"
                 matTooltip="Met à jour automatiquement les informations de l'établissement via l'API">
           <mat-icon class="mr-1" [class.spin]="autoUpdating">autorenew</mat-icon>
           {{ autoUpdating ? 'Mise à jour…' : 'Mise à jour automatique' }}

--- a/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.ts
+++ b/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.ts
@@ -105,6 +105,7 @@ export class EtabAccueilFormComponent implements OnInit, OnChanges, AfterViewIni
   nafN5List: any[] = [];
   creationSeulementHorsFrance : boolean = false;
   creationSeulementFrance : boolean = false;
+  isMajAutoDisabled : boolean = false;
 
   nafN5FilterCtrl: FormControl = new FormControl();
   filteredNafN5List: ReplaySubject<any> = new ReplaySubject<any>(1);
@@ -140,6 +141,7 @@ export class EtabAccueilFormComponent implements OnInit, OnChanges, AfterViewIni
       const autorisationCreationFrance = response.autoriserEtudiantACreerEntrepriseFrance;
       this.creationSeulementHorsFrance = autorisationCreationHorsFrance && !autorisationCreationFrance;
       this.creationSeulementFrance = !autorisationCreationHorsFrance && autorisationCreationFrance
+      this.isMajAutoDisabled = response.desactiverMajAutoEtabSelection;
     })
     this.paysService.getPaginated(1, 0, 'lib', 'asc', JSON.stringify({ temEnServPays: { value: 'O', type: 'text' } })).subscribe((response: any) => {
         this.countries = response.data;
@@ -757,7 +759,7 @@ export class EtabAccueilFormComponent implements OnInit, OnChanges, AfterViewIni
   }
 
   canUpdateFromApi(): boolean {
-    return !(this.authService.isEtudiant() || this.authService.isEnseignant()) && this.isSireneActive && this.etab?.id;
+    return !(this.authService.isEtudiant() || this.authService.isEnseignant()) && this.isSireneActive && this.etab?.id && this.etab.pays.id == 82;
   }
 
   // Méthode pour basculer l'état du verrouillage

--- a/src/main/java/org/esup_portail/esup_stage/controller/StructureController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/StructureController.java
@@ -305,7 +305,7 @@ public class StructureController {
         if(structureBody.getId() != null) {
             structure = structureJpaRepository.findById(structureBody.getId()).orElse(null);
             if (structure != null && structure.getTemEnServStructure()) {
-                if(structure.getNumeroSiret() != null && !structure.getNumeroSiret().isEmpty() && !structure.isVerrouillageSynchroStructureSirene()) {
+                if (structure.getNumeroSiret() != null && !structure.getNumeroSiret().isEmpty() && !structure.isVerrouillageSynchroStructureSirene() && !appConfigService.getConfigGenerale().isDesactiverMajAutoEtabSelection()) {
                     String jsonStructure;
                     try{
                         jsonStructure = objectMapper.writeValueAsString(structure);

--- a/src/main/java/org/esup_portail/esup_stage/dto/ConfigGeneraleDto.java
+++ b/src/main/java/org/esup_portail/esup_stage/dto/ConfigGeneraleDto.java
@@ -50,4 +50,6 @@ public class ConfigGeneraleDto {
 
     private boolean desactiverMajAutoEtabSelection = false;
 
+    private boolean desactiverMajAutoEtabDiffusionPartiel = false;
+
 }

--- a/src/main/java/org/esup_portail/esup_stage/dto/ConfigGeneraleDto.java
+++ b/src/main/java/org/esup_portail/esup_stage/dto/ConfigGeneraleDto.java
@@ -48,4 +48,6 @@ public class ConfigGeneraleDto {
     @JsonView(Views.Etu.class)
     private boolean autoriserEtudiantACreerEntrepriseHorsFrance = false;
 
+    private boolean desactiverMajAutoEtabSelection = false;
+
 }

--- a/src/main/java/org/esup_portail/esup_stage/model/AppConfig.java
+++ b/src/main/java/org/esup_portail/esup_stage/model/AppConfig.java
@@ -1,11 +1,14 @@
 package org.esup_portail.esup_stage.model;
 
 import jakarta.persistence.*;
+import lombok.Data;
 import org.esup_portail.esup_stage.enums.AppConfigCodeEnum;
 
 @Entity
+@Data
 @Table(name = "AppConfig")
 public class AppConfig {
+
     @Enumerated(EnumType.STRING)
     @Id
     @Column(name = "codeAppConfig", nullable = false)
@@ -15,19 +18,4 @@ public class AppConfig {
     @Column(nullable = false)
     private String parametres;
 
-    public AppConfigCodeEnum getCode() {
-        return code;
-    }
-
-    public void setCode(AppConfigCodeEnum code) {
-        this.code = code;
-    }
-
-    public String getParametres() {
-        return parametres;
-    }
-
-    public void setParametres(String parametres) {
-        this.parametres = parametres;
-    }
 }

--- a/src/main/java/org/esup_portail/esup_stage/service/sirene/model/SirenResponse.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/sirene/model/SirenResponse.java
@@ -83,6 +83,9 @@ public class SirenResponse {
             @JsonProperty("sexeUniteLegale")
             private String sexeUniteLegale;
 
+            @JsonProperty("statutDiffusionUniteLegale")
+            private String statutDiffusionUniteLegale;
+
         }
 
         @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
Fix pour l'issue #475 :

Ajout de deux paramètres permettant de verrouiller la mise à jour automatique :
- le premier pour verrouiller la mise à jour automatique sur l’ensemble des établissements d’accueil ;
- le second pour verrouiller la mise à jour automatique sur les établissements d’accueil en diffusion partielle (qui remontent notamment beaucoup de [ND]).

Légers ajustements au niveau des boutons de synchronisation.