### PR TITLE
Ajout du bouton de signature pour les applications de signature externe

### DIFF
--- a/src/frontend/src/app/components/convention/signature-electronique/signature-electronique.component.html
+++ b/src/frontend/src/app/components/convention/signature-electronique/signature-electronique.component.html
@@ -25,7 +25,7 @@
       <div class="alert alert-warning" *ngIf="!convention.dateEnvoiSignature">
         La convention n'a pas été envoyée pour signature électronique.
       </div>
-      <div class="alert alert-info" *ngIf="convention.dateEnvoiSignature && signatureType !== 'EXTERNE'">
+      <div class="alert alert-info" *ngIf="convention.dateEnvoiSignature">
         Docaposte et ESUP-Signature : les informations de signature sont mises à jour automatiquement tous les jours à 1h.<br/>
         Solutions externes : les informations de signature sont mis à jour automatiquement via webhook.<br/>
         L'actualisation des données n'est possible que toutes les 30 minutes.

--- a/src/main/java/org/esup_portail/esup_stage/service/signature/SignatureService.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/signature/SignatureService.java
@@ -304,9 +304,6 @@ public class SignatureService {
         if (appSignature == null) {
             throw new AppException(HttpStatus.BAD_REQUEST, "La signature électronique n'est pas configurée");
         }
-        if (appSignature == AppSignatureEnum.EXTERNE) {
-            throw new AppException(HttpStatus.NO_CONTENT, "La récupération de l'historique sera faite automatiquement");
-        }
 
         try {
             List<Historique> historiques = new ArrayList<>();
@@ -317,6 +314,9 @@ public class SignatureService {
                 case ESUPSIGNATURE:
                     historiques = webhookService.getHistorique(convention.getDocumentId(), convention);
                     break;
+                case EXTERNE:
+                    webhookService.getHistoriqueExterne(convention);
+                    return;
             }
             setSignatureHistorique(convention, historiques);
         } catch (Exception e) {
@@ -340,9 +340,6 @@ public class SignatureService {
         if (appSignature == null) {
             throw new AppException(HttpStatus.BAD_REQUEST, "La signature électronique n'est pas configurée");
         }
-        if (appSignature == AppSignatureEnum.EXTERNE) {
-            throw new AppException(HttpStatus.NO_CONTENT, "La récupération de l'historique sera faite automatiquement");
-        }
 
         try {
             List<Historique> historiques = new ArrayList<>();
@@ -353,6 +350,9 @@ public class SignatureService {
                 case ESUPSIGNATURE:
                     historiques = webhookService.getHistorique(avenant.getDocumentId(), avenant.getConvention());
                     break;
+                case EXTERNE:
+                    webhookService.getHistoriqueExterne(avenant);
+                    return;
             }
             setSignatureHistorique(avenant, historiques);
         } catch (Exception e) {
@@ -521,11 +521,14 @@ public class SignatureService {
         log.info("Fin de updateAuto()");
     }
 
-    //TODO : mettre a jour le update pour aller chercher les données (pour toutes les app de signature)
     public void update(Convention convention){
         AppSignatureEnum appSignature = signatureProperties.getAppSignatureType();
         try {
             List<Historique> historiques = new ArrayList<>();
+            if (appSignature == AppSignatureEnum.EXTERNE) {
+                webhookService.getHistoriqueExterne(convention);
+                return;
+            }
             historiques = switch (appSignature) {
                 case DOCAPOSTE -> signatureClient.getHistorique(convention.getDocumentId(), convention.getCentreGestion().getSignataires());
                 case ESUPSIGNATURE -> webhookService.getHistoriqueStatus(convention.getDocumentId(), convention);
@@ -585,11 +588,14 @@ public class SignatureService {
         }
     }
 
-    //TODO : mettre a jour le update pour aller chercher les données (pour toutes les app de signature)
     public void update(Avenant avenant){
         AppSignatureEnum appSignature = signatureProperties.getAppSignatureType();
         try {
             List<Historique> historiques = new ArrayList<>();
+            if (appSignature == AppSignatureEnum.EXTERNE) {
+                webhookService.getHistoriqueExterne(avenant);
+                return;
+            }
             historiques = switch (appSignature) {
                 case DOCAPOSTE -> signatureClient.getHistorique(avenant.getDocumentId(), avenant.getConvention().getCentreGestion().getSignataires());
                 case ESUPSIGNATURE -> webhookService.getHistorique(avenant.getDocumentId(), avenant.getConvention());

--- a/src/main/java/org/esup_portail/esup_stage/webhook/esupsignature/service/WebhookService.java
+++ b/src/main/java/org/esup_portail/esup_stage/webhook/esupsignature/service/WebhookService.java
@@ -1,14 +1,12 @@
 package org.esup_portail.esup_stage.webhook.esupsignature.service;
 
 import com.itextpdf.commons.utils.Base64;
-import jakarta.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.esup_portail.esup_stage.config.properties.SignatureProperties;
 import org.esup_portail.esup_stage.dto.MetadataDto;
 import org.esup_portail.esup_stage.dto.MetadataObservateurDto;
 import org.esup_portail.esup_stage.dto.MetadataSignataireDto;
 import org.esup_portail.esup_stage.dto.PdfMetadataDto;
-import org.esup_portail.esup_stage.enums.SignataireEnum;
 import org.esup_portail.esup_stage.exception.AppException;
 import org.esup_portail.esup_stage.model.Avenant;
 import org.esup_portail.esup_stage.model.CentreGestionSignataire;
@@ -214,19 +212,19 @@ public class WebhookService {
                     .uri(uri)
                     .header("Authorization", "Bearer " + signatureProperties.getWebhook().getToken())
                     .retrieve()
-                    .bodyToMono(String.class)
+                    .toEntity(String.class)
                     .block();
         } catch (WebClientResponseException e) {
             HttpStatus status = HttpStatus.valueOf(e.getStatusCode().value());
             logger.error("Erreur HTTP lors du refresh historique EXTERNE (conventionId={}, uri={}, status={})", convention.getId(), uri, status, e);
-            if (status == HttpStatus.UNAUTHORIZED) throw new AppException(HttpStatus.UNAUTHORIZED, "Accès non autorisé à l'application de signature externe");
-            if (status == HttpStatus.FORBIDDEN) throw new AppException(HttpStatus.FORBIDDEN, "Accès interdit à l'application de signature externe");
-            if (status == HttpStatus.NOT_FOUND) throw new AppException(HttpStatus.NOT_FOUND, "Endpoint externe de mise à jour d'historique introuvable");
-            if (status == HttpStatus.INTERNAL_SERVER_ERROR) throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur interne de l'application de signature externe");
-            throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur lors de l'appel à l'application de signature externe");
+            if (status == HttpStatus.UNAUTHORIZED) throw new AppException(HttpStatus.UNAUTHORIZED, "Accès non autorisé à l'application de signature");
+            if (status == HttpStatus.FORBIDDEN) throw new AppException(HttpStatus.FORBIDDEN, "Accès interdit à l'application de signature");
+            if (status == HttpStatus.NOT_FOUND) throw new AppException(HttpStatus.NOT_FOUND, "Convention non trouvé dans l'application de signature");
+            if (status == HttpStatus.INTERNAL_SERVER_ERROR) throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur interne de l'application de signature");
+            throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur lors de l'appel à l'application de signature");
         } catch (Exception e) {
             logger.error("Erreur technique lors du refresh historique EXTERNE (conventionId={}, uri={})", convention.getId(), uri, e);
-            throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur technique lors de la mise à jour externe de l'historique");
+            throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur technique lors de la mise à jour de l'historique");
         }
     }
 
@@ -241,15 +239,15 @@ public class WebhookService {
                     .block();
         } catch (WebClientResponseException e) {
             HttpStatus status = HttpStatus.valueOf(e.getStatusCode().value());
-            logger.error("Erreur HTTP lors du refresh historique EXTERNE (avenantId={}, uri={}, status={})", avenant.getId(), uri, status, e);
-            if (status == HttpStatus.UNAUTHORIZED) throw new AppException(HttpStatus.UNAUTHORIZED, "Accès non autorisé à l'application de signature externe");
-            if (status == HttpStatus.FORBIDDEN) throw new AppException(HttpStatus.FORBIDDEN, "Accès interdit à l'application de signature externe");
-            if (status == HttpStatus.NOT_FOUND) throw new AppException(HttpStatus.NOT_FOUND, "Endpoint externe de mise à jour d'historique introuvable");
-            if (status == HttpStatus.INTERNAL_SERVER_ERROR) throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur interne de l'application de signature externe");
-            throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur lors de l'appel à l'application de signature externe");
+            logger.error("Erreur HTTP lors du refresh historique (avenantId={}, uri={}, status={})", avenant.getId(), uri, status, e);
+            if (status == HttpStatus.UNAUTHORIZED) throw new AppException(HttpStatus.UNAUTHORIZED, "Accès non autorisé à l'application de signature");
+            if (status == HttpStatus.FORBIDDEN) throw new AppException(HttpStatus.FORBIDDEN, "Accès interdit à l'application de signature");
+            if (status == HttpStatus.NOT_FOUND) throw new AppException(HttpStatus.NOT_FOUND, "Avenant non trouvé dans l'application de signature");
+            if (status == HttpStatus.INTERNAL_SERVER_ERROR) throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur interne de l'application de signature");
+            throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur lors de l'appel à l'application de signature");
         } catch (Exception e) {
-            logger.error("Erreur technique lors du refresh historique EXTERNE (avenantId={}, uri={})", avenant.getId(), uri, e);
-            throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur technique lors de la mise à jour externe de l'historique");
+            logger.error("Erreur technique lors du refresh historique (avenantId={}, uri={})", avenant.getId(), uri, e);
+            throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "Erreur technique lors de la mise à jour de l'historique");
         }
     }
 }

--- a/src/main/java/org/esup_portail/esup_stage/webhook/esupsignature/service/WebhookService.java
+++ b/src/main/java/org/esup_portail/esup_stage/webhook/esupsignature/service/WebhookService.java
@@ -10,6 +10,7 @@ import org.esup_portail.esup_stage.dto.MetadataSignataireDto;
 import org.esup_portail.esup_stage.dto.PdfMetadataDto;
 import org.esup_portail.esup_stage.enums.SignataireEnum;
 import org.esup_portail.esup_stage.exception.AppException;
+import org.esup_portail.esup_stage.model.Avenant;
 import org.esup_portail.esup_stage.model.CentreGestionSignataire;
 import org.esup_portail.esup_stage.model.Convention;
 import org.esup_portail.esup_stage.service.signature.model.Historique;
@@ -202,4 +203,25 @@ public class WebhookService {
         return historiques;
     }
 
+    /*
+    * Déclenche une demande de mise à jour sur l'application de signature
+     */
+    public void getHistoriqueExterne(Convention convention) {
+
+        webClient.get()
+                .uri(signatureProperties.getWebhook().getUri() + "?conventionid=" + convention.getId())
+                .header("Authorization", "Bearer " + signatureProperties.getWebhook().getToken())
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+
+    public void getHistoriqueExterne(Avenant avenant) {
+        webClient.get()
+                .uri(signatureProperties.getWebhook().getUri() + "?avenantid=" + avenant.getId())
+                .header("Authorization", "Bearer " + signatureProperties.getWebhook().getToken())
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
 }


### PR DESCRIPTION
Le bouton de mise à jour, dans l’onglet Signature électronique de la convention, auparavant disponible uniquement pour la signature avec Docaposte et Esup-Signature, est désormais accessible pour les applications de signature externe.

Ce bouton permet à esup-stage d’envoyer un appel GET vers l’URL paramétrée pour le webhook de signature, avec l’identifiant de la convention ou de l’avenant, de la même manière que le POST utilisé pour l’ajout d’une convention en signature.

L’objectif est de déclencher une demande d’envoi des informations de signature par l’application de signature.