### PR TITLE
ajustements sur la gestion des établissements d'accueil partiellement diffusible

### DIFF
--- a/src/frontend/src/app/components/admin/config-generale/config-generale.component.html
+++ b/src/frontend/src/app/components/admin/config-generale/config-generale.component.html
@@ -306,21 +306,6 @@
               </mat-radio-group>
             </div>
           </div>
-          <div class="row mb-2">
-            <div class="col-md-12">
-              <div class="mb-2" [class.section-disabled]="!isSireneAcitve">Désactiver la mise à jour automatique via l'API Sirene si l'établissement est en diffusion partielle ?</div>
-              <mat-radio-group formControlName="desactiverMajAutoEtabDiffusionPartiel">
-                <mat-radio-button
-                  [disabled]="!isSireneAcitve || formGenerale.get('desactiverMajAutoEtabSelection')?.value === true"
-                  [value]="true"
-                >Oui</mat-radio-button>
-                <mat-radio-button
-                  [disabled]="!isSireneAcitve || formGenerale.get('desactiverMajAutoEtabSelection')?.value === true"
-                  [value]="false"
-                >Non</mat-radio-button>
-              </mat-radio-group>
-            </div>
-          </div>
           <div class="mt-3" *ngIf="canEdit()">
             <button mat-flat-button color="primary">Valider</button>
           </div>

--- a/src/frontend/src/app/components/admin/config-generale/config-generale.component.ts
+++ b/src/frontend/src/app/components/admin/config-generale/config-generale.component.ts
@@ -81,7 +81,6 @@ export class ConfigGeneraleComponent implements OnInit {
       autoriserEtudiantACreerEntrepriseFrance: [null],
       autoriserEtudiantACreerEntrepriseHorsFrance: [null],
       desactiverMajAutoEtabSelection: [null],
-      desactiverMajAutoEtabDiffusionPartiel: [null],
     });
 
     this.formTheme = this.fb.group({

--- a/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.html
+++ b/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.html
@@ -4,13 +4,13 @@
   <div class="row">
     <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
       <mat-label>Raison sociale</mat-label>
-      <input matInput formControlName="raisonSociale" required [disabled]="isRaisonSocialeOrSiretDisabled()" />
+      <input matInput formControlName="raisonSociale" required [disabled]="isRaisonSocialeDisabled()" />
       <mat-icon matSuffix class="icon-help" matTooltip="Nom de l'organisme">help</mat-icon>
       <mat-error *ngIf="form.get('raisonSociale')"></mat-error>
     </mat-form-field>
     <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill" [hidden]="!isFr()">
       <mat-label>Numéro Siret</mat-label>
-      <input matInput formControlName="numeroSiret" [required]="numeroSiretRequired() && isFr()" [disabled]="isRaisonSocialeOrSiretDisabled()" />
+      <input matInput formControlName="numeroSiret" [required]="numeroSiretRequired() && isFr()" [disabled]="isSiretDisabled()" />
       <mat-icon matSuffix class="icon-help" matTooltip="Code INSEE à demander à votre établissement d'accueil ou consultable sur des sites de référencement d'entreprises. Correspond à l'identifiant géographique de l'établissement. (format : 14 chiffres consécutifs sans espace - ex: 12345678912345)">help</mat-icon>
       <mat-error *ngIf="form.get('numeroSiret')"></mat-error>
     </mat-form-field>

--- a/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.html
+++ b/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.html
@@ -4,13 +4,13 @@
   <div class="row">
     <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
       <mat-label>Raison sociale</mat-label>
-      <input matInput formControlName="raisonSociale" [disabled]="isFieldDisabled()" required />
+      <input matInput formControlName="raisonSociale" required [disabled]="isRaisonSocialeOrSiretDisabled()" />
       <mat-icon matSuffix class="icon-help" matTooltip="Nom de l'organisme">help</mat-icon>
       <mat-error *ngIf="form.get('raisonSociale')"></mat-error>
     </mat-form-field>
     <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill" [hidden]="!isFr()">
       <mat-label>Numéro Siret</mat-label>
-      <input matInput formControlName="numeroSiret" [disabled]="isFieldDisabled()" [required]="numeroSiretRequired() && isFr()" />
+      <input matInput formControlName="numeroSiret" [required]="numeroSiretRequired() && isFr()" [disabled]="isRaisonSocialeOrSiretDisabled()" />
       <mat-icon matSuffix class="icon-help" matTooltip="Code INSEE à demander à votre établissement d'accueil ou consultable sur des sites de référencement d'entreprises. Correspond à l'identifiant géographique de l'établissement. (format : 14 chiffres consécutifs sans espace - ex: 12345678912345)">help</mat-icon>
       <mat-error *ngIf="form.get('numeroSiret')"></mat-error>
     </mat-form-field>
@@ -209,7 +209,7 @@
           <span class="sync-radio-label">Synchronisation automatique</span>
           <mat-radio-group
             [value]="etab.verrouillageSynchroStructureSirene ? 'non' : 'oui'"
-            [disabled]="isMajAutoDisabled"
+            [disabled]="isMajAutoDisabled || !etab.temDiffusibleSirene"
             (change)="toggleVerrouillage()"
             aria-label="Synchronisation automatique">
             <mat-radio-button value="oui">Oui</mat-radio-button>
@@ -218,13 +218,16 @@
         </div>
       </div>
 
-      <!-- Mise à jour automatique -->
       <div class="slot" *ngIf="canUpdateFromApi()">
-        <button type="button" mat-button mat-stroked-button color="primary" class="mr-2" [disabled]="autoUpdating" (click)="autoUpdateFromApi()"
-                matTooltip="Met à jour automatiquement les informations de l'établissement via l'API">
-          <mat-icon class="mr-1" [class.spin]="autoUpdating">autorenew</mat-icon>
-          {{ autoUpdating ? 'Mise à jour…' : 'Mise à jour automatique' }}
-        </button>
+        <div [matTooltip]="!etab.temDiffusibleSirene ? 'Cet établissement est partiellement diffusible et ne peut pas être mis à jour via l\'API Sirene' : 'Met à jour automatiquement les informations de l\'établissement via l\'API'"
+             style="display: inline-block;">
+          <button type="button" mat-button mat-stroked-button color="primary" class="mr-2"
+                  [disabled]="autoUpdating || !etab.temDiffusibleSirene"
+                  (click)="autoUpdateFromApi()">
+            <mat-icon class="mr-1" [class.spin]="autoUpdating">autorenew</mat-icon>
+            {{ autoUpdating ? 'Mise à jour…' : 'Mise à jour' }}
+          </button>
+        </div>
       </div>
 
       <!-- Valider -->

--- a/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.ts
+++ b/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.ts
@@ -460,8 +460,8 @@ export class EtabAccueilFormComponent implements OnInit, OnChanges, AfterViewIni
 
   ngOnChanges(changes: SimpleChanges): void {
     this.form = this.fb.group({
-      raisonSociale: [{ value: this.etab.raisonSociale, disabled: this.isFieldDisabled() }, [Validators.required, Validators.maxLength(150)]],
-      numeroSiret: [{ value: this.etab.numeroSiret, disabled: this.isFieldDisabled() }, [Validators.maxLength(14), Validators.pattern('[0-9]{14}')]],
+      raisonSociale: [this.etab.raisonSociale, [Validators.required, Validators.maxLength(150)]],
+      numeroSiret: [this.etab.numeroSiret, [Validators.maxLength(14), Validators.pattern('[0-9]{14}')]],
       idEffectif: [this.etab.effectif ? this.etab.effectif.id : null],
       idTypeStructure: [this.etab.typeStructure ? this.etab.typeStructure.id : null, [Validators.required]],
       idStatutJuridique: [this.etab.statutJuridique?.id ?? null, [Validators.required]],
@@ -502,6 +502,11 @@ export class EtabAccueilFormComponent implements OnInit, OnChanges, AfterViewIni
         this.lastNafListKey = currentKey;
         this.loadNafN5List();
       }
+    }
+
+    if (this.isRaisonSocialeOrSiretDisabled()) {
+      this.form.get('raisonSociale')?.disable();
+      this.form.get('numeroSiret')?.disable();
     }
   }
 
@@ -680,6 +685,14 @@ export class EtabAccueilFormComponent implements OnInit, OnChanges, AfterViewIni
 
   isFieldDisabled(): boolean {
       return !!this.etab?.id ? !this.canEdit() : !this.canCreate();
+  }
+
+  isRaisonSocialeOrSiretDisabled(): boolean {
+    const hasRights = this.authService.checkRights({
+      fonction: AppFonction.ORGA_ACC,
+      droits: [Droit.CREATION, Droit.MODIFICATION]
+    });
+    return hasRights && this.etab?.temSiren === true && this.etab?.temDiffusibleSirene === true;
   }
 
   private filterCountries(): void {

--- a/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.ts
+++ b/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.ts
@@ -504,8 +504,10 @@ export class EtabAccueilFormComponent implements OnInit, OnChanges, AfterViewIni
       }
     }
 
-    if (this.isRaisonSocialeOrSiretDisabled()) {
+    if (this.isRaisonSocialeDisabled()) {
       this.form.get('raisonSociale')?.disable();
+    }
+    if (this.isSiretDisabled()) {
       this.form.get('numeroSiret')?.disable();
     }
   }
@@ -687,13 +689,14 @@ export class EtabAccueilFormComponent implements OnInit, OnChanges, AfterViewIni
       return !!this.etab?.id ? !this.canEdit() : !this.canCreate();
   }
 
-  isRaisonSocialeOrSiretDisabled(): boolean {
-    const hasRights = this.authService.checkRights({
-      fonction: AppFonction.ORGA_ACC,
-      droits: [Droit.CREATION, Droit.MODIFICATION]
-    });
-    return hasRights && this.etab?.temSiren === true && this.etab?.temDiffusibleSirene === true;
+  isRaisonSocialeDisabled(): boolean {
+    return this.isFieldDisabled() && this.etab?.temSiren === true && this.etab?.temDiffusibleSirene === true;
   }
+
+
+    isSiretDisabled(): boolean {
+      return this.isFieldDisabled() && this.etab?.temSiren === true;
+    }
 
   private filterCountries(): void {
     if (!this.countries || !Array.isArray(this.countries)) {

--- a/src/main/java/org/esup_portail/esup_stage/dto/ConfigGeneraleDto.java
+++ b/src/main/java/org/esup_portail/esup_stage/dto/ConfigGeneraleDto.java
@@ -50,6 +50,4 @@ public class ConfigGeneraleDto {
 
     private boolean desactiverMajAutoEtabSelection = false;
 
-    private boolean desactiverMajAutoEtabDiffusionPartiel = false;
-
 }

--- a/src/main/java/org/esup_portail/esup_stage/model/Structure.java
+++ b/src/main/java/org/esup_portail/esup_stage/model/Structure.java
@@ -134,6 +134,9 @@ public class Structure extends ObjetMetier implements Exportable {
     @Column
     private boolean verrouillageSynchroStructureSirene;
 
+    @Column
+    private boolean temDiffusibleSirene;
+
     public Structure() {
     }
 

--- a/src/main/java/org/esup_portail/esup_stage/service/sirene/SireneService.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/sirene/SireneService.java
@@ -153,9 +153,15 @@ public class SireneService {
                     url, HttpMethod.GET, entity, SirenResponse.class
             );
             if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
-                if ((!isDiffusionComplete(response.getBody())) && appConfigService.getConfigGenerale().isDesactiverMajAutoEtabDiffusionPartiel() ) {
+                if ((!isDiffusionComplete(response.getBody()))) {
                     logger.warn("Mise à jour ignorée (diffusion partielle) pour l'établissement id={} siret={}",
                             structure.getId(), structure.getNumeroSiret());
+                    if (structure.isTemDiffusibleSirene()){
+                        structure.setTemDiffusibleSirene(false);
+                        structure.setVerrouillageSynchroStructureSirene(true);
+                        structureJpaRepository.save(structure);
+                        eventPublisher.publishEvent(new StructureUpdatedEvent(structure,oldStructureJson,objectMapper.writeValueAsString(structure),true));
+                    }
                     return;
                 }
                 structure = sirenMapper.updateStructure(response.getBody(), structure);

--- a/src/main/java/org/esup_portail/esup_stage/service/sirene/utils/SireneMapper.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/sirene/utils/SireneMapper.java
@@ -92,6 +92,10 @@ public class SireneMapper {
         structure.setEstValidee(false);
         structure.setTemEnServStructure(true);
         structure.setTemSiren(true);
+        structure.setTemDiffusibleSirene(isDiffusionComplete(etablissement));
+        if (!structure.isTemDiffusibleSirene()) {
+            structure.setVerrouillageSynchroStructureSirene(true);
+        }
 
         return structure;
     }
@@ -400,5 +404,13 @@ public class SireneMapper {
         }
 
         return resultat;
+    }
+
+    private boolean isDiffusionComplete(SirenResponse.EtablissementSiren etab) {
+        if (etab.getUniteLegale() == null) {
+            return false;
+        }
+        String statut = etab.getUniteLegale().getStatutDiffusionUniteLegale();
+        return "O".equalsIgnoreCase(statut);
     }
 }

--- a/src/main/resources/db/changelog/3.1.12-ajout-temoin-diffusible-sirene.yaml
+++ b/src/main/resources/db/changelog/3.1.12-ajout-temoin-diffusible-sirene.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.1.12-ajout-temoin-diffusible-sirene
+      author: thouveno9
+      changes:
+        - addColumn:
+            tableName: Structure
+            columns:
+              - column:
+                  name: temDiffusibleSirene
+                  type: boolean
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -282,3 +282,6 @@ databaseChangeLog:
   - include:
         file: 3.2.0-ajout-bool-verrouillage-synchro-etab.yaml
         relativeToChangelogFile: true
+  - include:
+      file: 3.1.12-ajout-temoin-diffusible-sirene.yaml
+      relativeToChangelogFile: true


### PR DESCRIPTION

- Le paramètre Mise à jour automatique pour les établissements d’accueil en diffusion partielle est maintenant activé par défaut et retiré de l’interface.

- Pour ces établissements, la modification de la raison sociale est autorisée.

- Le bouton Mise à jour automatique est désactivé (grisé) et affiche un tooltip indiquant : 
« Cet établissement est partiellement diffusible et ne peut pas être mis à jour via l’API Sirene »

- Le bouton « Mise à jour automatique » est renommé en « Mise à jour » afin de clarifier son usage.