### PR TITLE
Issue #429 – Correction des droits de modification des étudiants sur les établissements d’accueil

### DIFF
--- a/src/frontend/src/app/components/convention/etab-accueil/etab-accueil.component.html
+++ b/src/frontend/src/app/components/convention/etab-accueil/etab-accueil.component.html
@@ -110,7 +110,7 @@
             <button mat-button mat-stroked-button color="primary" *ngIf="etab.id && modifiable" (click)="changeOnglet()">Changer d'établissement</button>
           </div>
           <div class="col-md-3">
-            <button mat-button mat-stroked-button color="primary" *ngIf="etab.id && !modif && (canEdit() || (isCreatorEtab(etab) && !etab.temSiren))" (click)="edit()">Modifier ces informations</button>
+            <button mat-button mat-stroked-button color="primary" *ngIf="etab.id && !modif && modifiable && (canEdit() || (isCreatorEtab(etab) && !etab.temSiren))" (click)="edit()">Modifier ces informations</button>
           </div>
         </div>
       </div>

--- a/src/frontend/src/app/components/convention/etab-accueil/etab-accueil.component.html
+++ b/src/frontend/src/app/components/convention/etab-accueil/etab-accueil.component.html
@@ -110,7 +110,7 @@
             <button mat-button mat-stroked-button color="primary" *ngIf="etab.id && modifiable" (click)="changeOnglet()">Changer d'établissement</button>
           </div>
           <div class="col-md-3">
-            <button mat-button mat-stroked-button color="primary" *ngIf="etab.id && !modif && (canEdit() || isCreatorEtab(etab))" (click)="edit()">Modifier ces informations</button>
+            <button mat-button mat-stroked-button color="primary" *ngIf="etab.id && !modif && (canEdit() || (isCreatorEtab(etab) && !etab.temSiren))" (click)="edit()">Modifier ces informations</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Autoriser la modification de l’établissement par l’étudiant uniquement s’il n’a pas été récupéré via l’API Sirene.
- Interdire la modification de l’établissement d’accueil par l’étudiant lorsque la convention a été validée.