### PR TITLE
Modification de la raison sociale par les admins

### DIFF
--- a/src/frontend/src/app/components/admin/config-generale/config-generale.component.html
+++ b/src/frontend/src/app/components/admin/config-generale/config-generale.component.html
@@ -306,6 +306,15 @@
               </mat-radio-group>
             </div>
           </div>
+          <div class="row mb-2">
+            <div class="col-md-12">
+              <div class="mb-2" [class.section-disabled]="!isSireneAcitve">Autoriser les gestionnaires et les responsables gestionnaires à modifier la raison sociale des établissements issue de l’API Sirene ?</div>
+              <mat-radio-group formControlName="modifRaisonSocialeGestionnaire">
+                <mat-radio-button [disabled]="!isSireneAcitve" [value]="true">Oui</mat-radio-button>
+                <mat-radio-button [disabled]="!isSireneAcitve" [value]="false">Non</mat-radio-button>
+              </mat-radio-group>
+            </div>
+          </div>
           <div class="mt-3" *ngIf="canEdit()">
             <button mat-flat-button color="primary">Valider</button>
           </div>

--- a/src/frontend/src/app/components/admin/config-generale/config-generale.component.html
+++ b/src/frontend/src/app/components/admin/config-generale/config-generale.component.html
@@ -299,19 +299,19 @@
           </div>
           <div class="row mb-2">
             <div class="col-md-12">
-              <div class="mb-2" [class.section-disabled]="!isSireneAcitve">Désactiver la mise à jour automatique via l'API Sirene lors de la sélection d'un établissement ?</div>
+              <div class="mb-2" [class.section-disabled]="!isSireneActive">Désactiver la mise à jour automatique via l'API Sirene lors de la sélection d'un établissement ?</div>
               <mat-radio-group formControlName="desactiverMajAutoEtabSelection">
-                <mat-radio-button [disabled]="!isSireneAcitve" [value]="true">Oui</mat-radio-button>
-                <mat-radio-button [disabled]="!isSireneAcitve" [value]="false">Non</mat-radio-button>
+                <mat-radio-button [disabled]="!isSireneActive" [value]="true">Oui</mat-radio-button>
+                <mat-radio-button [disabled]="!isSireneActive" [value]="false">Non</mat-radio-button>
               </mat-radio-group>
             </div>
           </div>
           <div class="row mb-2">
             <div class="col-md-12">
-              <div class="mb-2" [class.section-disabled]="!isSireneAcitve">Autoriser les gestionnaires et les responsables gestionnaires à modifier la raison sociale des établissements issue de l’API Sirene ?</div>
+              <div class="mb-2" [class.section-disabled]="!isSireneActive">Autoriser les gestionnaires et les responsables gestionnaires à modifier la raison sociale des établissements issue de l’API Sirene ?</div>
               <mat-radio-group formControlName="modifRaisonSocialeGestionnaire">
-                <mat-radio-button [disabled]="!isSireneAcitve" [value]="true">Oui</mat-radio-button>
-                <mat-radio-button [disabled]="!isSireneAcitve" [value]="false">Non</mat-radio-button>
+                <mat-radio-button [disabled]="!isSireneActive" [value]="true">Oui</mat-radio-button>
+                <mat-radio-button [disabled]="!isSireneActive" [value]="false">Non</mat-radio-button>
               </mat-radio-group>
             </div>
           </div>

--- a/src/frontend/src/app/components/admin/config-generale/config-generale.component.ts
+++ b/src/frontend/src/app/components/admin/config-generale/config-generale.component.ts
@@ -56,7 +56,7 @@ export class ConfigGeneraleComponent implements OnInit {
   formSignature: FormGroup;
 
   isEtuAutoriseToCreate!: boolean;
-  isSireneAcitve!: boolean;
+  isSireneActive!: boolean;
 
   constructor(
     private configService: ConfigService,
@@ -142,7 +142,7 @@ export class ConfigGeneraleComponent implements OnInit {
 
     // Récupération des infos sirene
     this.structureService.getSireneInfo().subscribe((response: any) => {
-      this.isSireneAcitve = response.isApiSireneActive;
+      this.isSireneActive = response.isApiSireneActive;
       this.syncDiffusionPartielControl(this.formGenerale.get('desactiverMajAutoEtabSelection')?.value === true);
     });
   }

--- a/src/frontend/src/app/components/admin/config-generale/config-generale.component.ts
+++ b/src/frontend/src/app/components/admin/config-generale/config-generale.component.ts
@@ -81,6 +81,7 @@ export class ConfigGeneraleComponent implements OnInit {
       autoriserEtudiantACreerEntrepriseFrance: [null],
       autoriserEtudiantACreerEntrepriseHorsFrance: [null],
       desactiverMajAutoEtabSelection: [null],
+      modifRaisonSocialeGestionnaire : [null],
     });
 
     this.formTheme = this.fb.group({

--- a/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.ts
+++ b/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.ts
@@ -690,7 +690,7 @@ export class EtabAccueilFormComponent implements OnInit, OnChanges, AfterViewIni
   }
 
   isRaisonSocialeDisabled(): boolean {
-    return this.isFieldDisabled() && this.etab?.temSiren === true && this.etab?.temDiffusibleSirene === true;
+    return this.authService.isAdmin()? false : this.isFieldDisabled() && this.etab?.temSiren === true && this.etab?.temDiffusibleSirene === true;
   }
 
 

--- a/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.ts
+++ b/src/frontend/src/app/components/gestion-etab-accueil/etab-accueil-form/etab-accueil-form.component.ts
@@ -106,7 +106,7 @@ export class EtabAccueilFormComponent implements OnInit, OnChanges, AfterViewIni
   creationSeulementHorsFrance : boolean = false;
   creationSeulementFrance : boolean = false;
   isMajAutoDisabled : boolean = false;
-
+  isModifRaisonSocialeGestionnaire : boolean = false;
   nafN5FilterCtrl: FormControl = new FormControl();
   filteredNafN5List: ReplaySubject<any> = new ReplaySubject<any>(1);
   paysFilterCtrl: FormControl = new FormControl('');
@@ -142,6 +142,7 @@ export class EtabAccueilFormComponent implements OnInit, OnChanges, AfterViewIni
       this.creationSeulementHorsFrance = autorisationCreationHorsFrance && !autorisationCreationFrance;
       this.creationSeulementFrance = !autorisationCreationHorsFrance && autorisationCreationFrance
       this.isMajAutoDisabled = response.desactiverMajAutoEtabSelection;
+      this.isModifRaisonSocialeGestionnaire = response.modifRaisonSocialeGestionnaire;
     })
     this.paysService.getPaginated(1, 0, 'lib', 'asc', JSON.stringify({ temEnServPays: { value: 'O', type: 'text' } })).subscribe((response: any) => {
         this.countries = response.data;
@@ -690,7 +691,7 @@ export class EtabAccueilFormComponent implements OnInit, OnChanges, AfterViewIni
   }
 
   isRaisonSocialeDisabled(): boolean {
-    return this.authService.isAdmin()? false : this.isFieldDisabled() && this.etab?.temSiren === true && this.etab?.temDiffusibleSirene === true;
+    return !(this.authService.isAdmin() || (this.authService.isGestionnaire() && this.isModifRaisonSocialeGestionnaire)) && this.isFieldDisabled() && this.etab?.temSiren === true && this.etab?.temDiffusibleSirene === true;
   }
 
 

--- a/src/main/java/org/esup_portail/esup_stage/dto/ConfigGeneraleDto.java
+++ b/src/main/java/org/esup_portail/esup_stage/dto/ConfigGeneraleDto.java
@@ -50,4 +50,6 @@ public class ConfigGeneraleDto {
 
     private boolean desactiverMajAutoEtabSelection = false;
 
+    private boolean modifRaisonSocialeGestionnaire = false;
+
 }


### PR DESCRIPTION
Permet aux administrateurs de toujours pouvoir modifier la raison sociale des établissements d’accueil.