### PR TITLE
issue #465 - conventions en masse: affichage du nom du groupe

### DIFF
--- a/src/frontend/src/app/components/convention-create-en-masse/convention-create-en-masse.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/convention-create-en-masse.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from "@angular/router";
-import { GroupeEtudiantService } from "../../services/groupe-etudiant.service";
+import {GroupeEtudiant, GroupeEtudiantService} from "../../services/groupe-etudiant.service";
 import { UfrService } from "../../services/ufr.service";
 import { EtapeService } from "../../services/etape.service";
 import { forkJoin } from 'rxjs';
@@ -61,18 +61,14 @@ export class ConventionCreateEnMasseComponent implements OnInit {
       if (pathId === 'create') {
         this.titleService.title = 'Création de conventions en masse';
         // Récupération du groupeEtudiant au mode brouillon
-        this.groupeEtudiantService.getBrouillon().subscribe((response: any) => {
-          this.groupeEtudiant = response;
-          this.majFilter();
-          this.majStatus();
+        this.groupeEtudiantService.getBrouillon().subscribe((response: GroupeEtudiant) => {
+          this.updateGroupeEtudiant(response)
         });
       } else {
         this.titleService.title = 'Modification de conventions en masse';
         // Récupération du groupeEtudiant correspondant à l'id
-        this.groupeEtudiantService.getById(pathId).subscribe((response: any) => {
-          this.groupeEtudiant = response;
-          this.majFilter();
-          this.majStatus();
+        this.groupeEtudiantService.getById(pathId).subscribe((response: GroupeEtudiant) => {
+          this.updateGroupeEtudiant(response);
         });
       }
     });
@@ -221,8 +217,9 @@ export class ConventionCreateEnMasseComponent implements OnInit {
     this.tabs[0].init = true;
   }
 
-  updateGroupeEtudiant(data: any): void {
+  updateGroupeEtudiant(data?: GroupeEtudiant): void {
     this.groupeEtudiant = data;
+    this.titleService.subtitle = this.groupeEtudiant?.nom
     this.majFilter();
     this.majStatus();
   }

--- a/src/frontend/src/app/components/convention-create-en-masse/gestion-groupe/gestion-groupe.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/gestion-groupe/gestion-groupe.component.ts
@@ -13,6 +13,7 @@ import { Router } from "@angular/router";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { MatTabChangeEvent, MatTabGroup } from "@angular/material/tabs";
 import * as FileSaver from 'file-saver';
+import {TitleService} from "../../../services/title.service";
 
 @Component({
   selector: 'app-gestion-groupe',
@@ -67,6 +68,7 @@ export class GestionGroupeComponent implements OnInit {
     public templateMailGroupeService: TemplateMailGroupeService,
     private fb: FormBuilder,
     private messageService: MessageService,
+    private titleService: TitleService,
     private router: Router
   ) {
     this.form = this.fb.group({
@@ -159,6 +161,7 @@ export class GestionGroupeComponent implements OnInit {
   tabChanged(event: MatTabChangeEvent): void {
     this.selected = [];
     if (event.index == 0) {
+      this.titleService.subtitle = undefined;
       this.groupeEtudiant = {};
     }else{
       this.refreshFilters();
@@ -171,6 +174,7 @@ export class GestionGroupeComponent implements OnInit {
 
   printTab(row: any): void{
     this.groupeEtudiant = row;
+    this.titleService.subtitle = this.groupeEtudiant?.nom;
     if (this.tabs) {
       this.tabs.selectedIndex = this.printTabIndex;
     }
@@ -178,6 +182,7 @@ export class GestionGroupeComponent implements OnInit {
 
   sendMailTab(row: any): void{
     this.groupeEtudiant = row;
+    this.titleService.subtitle = this.groupeEtudiant?.nom;
     if (this.tabs) {
       this.tabs.selectedIndex = this.mailTabIndex;
     }

--- a/src/frontend/src/app/components/title/title.component.html
+++ b/src/frontend/src/app/components/title/title.component.html
@@ -1,3 +1,4 @@
 <div class="app-title text-center">
   <h3>{{getTitle()}}</h3>
+  @if (getSubTitle()) {<h4>{{getSubTitle()}}</h4>}
 </div>

--- a/src/frontend/src/app/components/title/title.component.ts
+++ b/src/frontend/src/app/components/title/title.component.ts
@@ -17,4 +17,8 @@ export class TitleComponent implements OnInit {
     return this.titleService.title;
   }
 
+  getSubTitle(): string | undefined {
+    return this.titleService.subtitle;
+  }
+
 }

--- a/src/frontend/src/app/services/title.service.ts
+++ b/src/frontend/src/app/services/title.service.ts
@@ -6,6 +6,7 @@ import { Injectable } from '@angular/core';
 export class TitleService {
 
   private _title: string = '';
+  private _subtitle?: string;
 
   constructor() { }
 
@@ -15,5 +16,14 @@ export class TitleService {
 
   set title(value: string) {
     this._title = value;
+    this._subtitle = undefined;
+  }
+
+  get subtitle(): string|undefined {
+    return this._subtitle;
+  }
+
+  set subtitle(value: string|undefined) {
+    this._subtitle = value;
   }
 }


### PR DESCRIPTION
## Description / Objectif / Motivation / Contexte
<!-- Pourquoi ce changement est-il important ?
    Quel problème résout-il ?
    Veuillez inclure un résumé des modifications et du problème associé.
    Veuillez également inclure la motivation et le contexte pertinent.
    Énumérez toutes les dépendances requises par ce changement.
-->
Dans la gestion des conventions en masse, les gestionnaires peuvent travailler/avancer sur plusieurs groupes.

Cette PR propose l'affichage du nom du groupe en sous-titre.

<!--- Si vous suggérez une nouvelle fonctionnalité ou un changement,
      merci d'ouvrir un ticket (issue) avant -->
Ticket: Fixes #465

## Cas d'acceptance (Comment cela a-t-il été testé ?)
<!-- ou lien https://... vers ticket avec les cas de test
Si vous corrigez un⋅e bogue, il devrait y avoir un ticket
le décrivant avec des étapes pour le reproduire -->

<!--
Veuillez décrire les tests que vous avez effectués pour vérifier vos modifications.
Fournir des instructions pour que nous puissions reproduire.
Veuillez également énumérer tous les détails pertinents de votre configuration de test.
-->

1. - Étant donné une composante _COMP_ et une étape _ETAPE_ avec des étudiants
   - Quand je suis sur la page _Créer des conventions en masse_
   - Quand je saisis un code de groupe _COD_GROUPE_ et un nom de groupe _nom_du_groupe_
   - Quand je choisis la composante _COMP_ et l'étape _ETAPE_
   - Quand je sélectionne un⋅e étudiant⋅e
   - Quand je clique sur l'action Valider (sous le code du groupe)
   - Alors le nom du groupe _nom_du_groupe_ apparaît sous le titre “Création de conventions en masse”
   - Quand je change d'onglet
   - Alors le nom du groupe _nom_du_groupe_ apparaît encore sous le titre “Création de conventions en masse”

2. - Étant donné un groupe _COD_GROUPE_ avec un nom de groupe _nom_du_groupe_
   - Quand je suis sur la page _Gestion des groupes_
   - Quand je choisis de modifier 🖊️ ce groupe _COD_GROUPE_
   - Alors le nom du groupe _nom_du_groupe_ apparaît sous le titre “Modification de conventions en masse”
   - Quand je change d'onglet
   - Alors le nom du groupe _nom_du_groupe_ apparaît encore sous le titre “Modification de conventions en masse”

<!-- Mentionnez s'il y a des tests automatisés pour ce changement 🙏 -->
<!-- Joindre des captures d'écran (le cas échéant) -->
### Tests automatisés
* aucun

## Type

<!--Veuillez supprimer des options qui ne sont pas pertinentes.-->
- ~☐ Correction de bogue (modification non cassante qui résout un problème).~
- 🗹 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
- ~☐ Changement cassant (correction qui entraînerait la/une fonctionnalité existante à ne pas fonctionner comme précédemment).~
- ~☐ Changement nécessitant une mise à jour de la documentation utilisateur.~

## Definition du fini

- [ ] Les cas d'acceptance ci-dessus ont été vérifiés.
- [ ] Revue par au moins un⋅e relecteur⋅ice autorisé⋅e.
- ~☐ Documentation(s) mise(s) à jour (utilisateur, technique, commentaires de code compris).~
- ~☐ Si des changements _cassants_ sont introduits, ils sont dûment décrits
  et les étapes de montée de version décrites (éventuellement scriptés).~