### PR TITLE
Correction issue #515

### DIFF
--- a/src/frontend/src/app/components/convention/avenant/avenant-form/avenant-form.component.html
+++ b/src/frontend/src/app/components/convention/avenant/avenant-form/avenant-form.component.html
@@ -3,7 +3,7 @@
     <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
       <mat-label>Titre</mat-label>
       <input matInput maxlength="{{MAX_LENTGH_INPUT.titreAvenant}}" formControlName="titreAvenant" required />
-      <mat-hint *ngIf="isLongTextLimitReached('sujetStage')" style="color:#c62828;">
+      <mat-hint *ngIf="isLongTextLimitReached('sujetStage')" style="color:var(--dangerColor);">
         Limite de {{ MAX_LENTGH_INPUT.titreAvenant }} caractères atteinte
       </mat-hint>
       <mat-error><app-form-error [field]="form.get('titreAvenant')"></app-form-error></mat-error>
@@ -42,7 +42,7 @@
       <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
         <mat-label>Commentaire(s)</mat-label>
         <textarea matInput maxlength="{{MAX_LENTGH_INPUT.longText}}" formControlName="commentaireRupture"></textarea>
-        <mat-hint *ngIf="isLongTextLimitReached('commentaireRupture')" style="color:#c62828;">
+        <mat-hint *ngIf="isLongTextLimitReached('commentaireRupture')" style="color:var(--dangerColor);">
           Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
         </mat-hint>
         <mat-error><app-form-error [field]="form.get('commentaireRupture')"></app-form-error></mat-error>
@@ -82,8 +82,7 @@
     <div class="row" *ngIf="convention.interruptionStage">
       <div class="col-sm-3 font-weight-bold">Périodes d'interruption du stage</div>
       <div class="col-sm-9"><span *ngFor="let interruption of interruptionsStage">
-          {{(interruptionsStage.length>1?'- Du ':'Du ') + (interruption.dateDebutInterruption|date:'shortDate') + ' au
-          '+ (interruption.dateFinInterruption|date:'shortDate')}}<br></span>
+          {{(interruptionsStage.length>1?'- Du ':'Du ') + (interruption.dateDebutInterruption|date:'shortDate') + ' au '+ (interruption.dateFinInterruption|date:'shortDate')}}<br></span>
       </div>
     </div>
     <div class="row mt-3 mb-3">
@@ -147,8 +146,7 @@
     <div class="row mt-3 mb-3">
       <div class="col-6">
         <button mat-button mat-flat-button type="button" color="primary"
-          (click)="openInterruptionsCreateFormModal()">{{addedInterruptionsStage.length === 0 ?'Ajouter des':'Gérer
-          les'}} nouvelles périodes d'interruptions</button>
+          (click)="openInterruptionsCreateFormModal()">{{addedInterruptionsStage.length === 0 ?'Ajouter des':'Gérer les'}} nouvelles périodes d'interruptions</button>
       </div>
     </div>
   </div>
@@ -431,7 +429,7 @@
       <mat-form-field class="col mb-2" appearance="fill">
         <mat-label>Motif de la modification</mat-label>
         <textarea matInput maxlength="{{MAX_LENTGH_INPUT.longText}}" rows="10" formControlName="motifAvenant" required></textarea>
-        <mat-hint *ngIf="isLongTextLimitReached('motifAvenant')" style="color:#c62828;">
+        <mat-hint *ngIf="isLongTextLimitReached('motifAvenant')" style="color:var(--dangerColor);">
           Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
         </mat-hint>
         <mat-error><app-form-error [field]="form.get('motifAvenant')"></app-form-error></mat-error>

--- a/src/frontend/src/app/components/convention/avenant/avenant-form/avenant-form.component.html
+++ b/src/frontend/src/app/components/convention/avenant/avenant-form/avenant-form.component.html
@@ -2,7 +2,10 @@
   <div class="row">
     <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
       <mat-label>Titre</mat-label>
-      <input matInput formControlName="titreAvenant" required />
+      <input matInput maxlength="{{MAX_LENTGH_INPUT.titreAvenant}}" formControlName="titreAvenant" required />
+      <mat-hint *ngIf="isLongTextLimitReached('sujetStage')" style="color:#c62828;">
+        Limite de {{ MAX_LENTGH_INPUT.titreAvenant }} caractères atteinte
+      </mat-hint>
       <mat-error><app-form-error [field]="form.get('titreAvenant')"></app-form-error></mat-error>
     </mat-form-field>
   </div>
@@ -38,7 +41,10 @@
       </mat-form-field>
       <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
         <mat-label>Commentaire(s)</mat-label>
-        <textarea matInput formControlName="commentaireRupture"></textarea>
+        <textarea matInput maxlength="{{MAX_LENTGH_INPUT.longText}}" formControlName="commentaireRupture"></textarea>
+        <mat-hint *ngIf="isLongTextLimitReached('commentaireRupture')" style="color:#c62828;">
+          Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+        </mat-hint>
         <mat-error><app-form-error [field]="form.get('commentaireRupture')"></app-form-error></mat-error>
       </mat-form-field>
     </div>
@@ -424,7 +430,10 @@
     <div class="row mt-3 mb-3">
       <mat-form-field class="col mb-2" appearance="fill">
         <mat-label>Motif de la modification</mat-label>
-        <textarea matInput rows="10" formControlName="motifAvenant" required></textarea>
+        <textarea matInput maxlength="{{MAX_LENTGH_INPUT.longText}}" rows="10" formControlName="motifAvenant" required></textarea>
+        <mat-hint *ngIf="isLongTextLimitReached('motifAvenant')" style="color:#c62828;">
+          Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+        </mat-hint>
         <mat-error><app-form-error [field]="form.get('motifAvenant')"></app-form-error></mat-error>
       </mat-form-field>
     </div>

--- a/src/frontend/src/app/components/convention/avenant/avenant-form/avenant-form.component.ts
+++ b/src/frontend/src/app/components/convention/avenant/avenant-form/avenant-form.component.ts
@@ -24,6 +24,7 @@ import { InterruptionsFormComponent } from '../../../convention/stage/interrupti
 import { debounceTime } from "rxjs/operators";
 import * as FileSaver from 'file-saver';
 import { ConventionService } from 'src/app/services/convention.service';
+import {MAX_LENTGH_INPUT} from "../../../../constants/max-length-input";
 
 @Component({
   selector: 'app-avenant-form',
@@ -31,10 +32,6 @@ import { ConventionService } from 'src/app/services/convention.service';
   styleUrls: ['./avenant-form.component.scss']
 })
 export class AvenantFormComponent implements OnInit {
-
-  fieldValidators: any = {
-    'dateRupture': [Validators.required],
-  }
 
   checkboxFields: any = ['dateRupture', 'modificationPeriode', 'modificationLieu', 'modificationSujet', 'modificationSalarie',
     'modificationEnseignant', 'modificationMontantGratification', 'modificationAutre'];
@@ -154,10 +151,10 @@ export class AvenantFormComponent implements OnInit {
 
     if (this.avenant.id) {
       this.form = this.fb.group({
-        titreAvenant: [this.avenant.titreAvenant],
+        titreAvenant: [this.avenant.titreAvenant, [Validators.maxLength(MAX_LENTGH_INPUT.titreAvenant)]],
         rupture: [this.avenant.rupture],
         dateRupture: [this.avenant.dateRupture ? new Date(this.avenant.dateRupture) : null],
-        commentaireRupture: [this.avenant.commentaireRupture],
+        commentaireRupture: [this.avenant.commentaireRupture, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
         modificationPeriode: [this.avenant.modificationPeriode],
         dateDebutStage: [this.avenant.dateDebutStage ? new Date(this.avenant.dateDebutStage) : null],
         dateFinStage: [this.avenant.dateFinStage ? new Date(this.avenant.dateFinStage) : null],
@@ -177,7 +174,7 @@ export class AvenantFormComponent implements OnInit {
         idDevise: [this.avenant.devise ? this.avenant.devise.id : null],
         validationAvenant: [this.avenant.validationAvenant],
         modificationAutre: [this.avenant.motifAvenant ? true : false],
-        motifAvenant: [this.avenant.motifAvenant],
+        motifAvenant: [this.avenant.motifAvenant, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       });
     } else {
       this.form = this.fb.group({
@@ -593,4 +590,15 @@ export class AvenantFormComponent implements OnInit {
       FileSaver.saveAs(blob, filename);
     });
   }
+
+  longTextLength(fieldName: string): number {
+    const value = this.form?.get(fieldName)?.value;
+    return typeof value === 'string' ? value.length : 0;
+  }
+
+  isLongTextLimitReached(fieldName: string): boolean {
+    return this.longTextLength(fieldName) >= MAX_LENTGH_INPUT.longText;
+  }
+
+  protected readonly MAX_LENTGH_INPUT = MAX_LENTGH_INPUT;
 }

--- a/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.html
+++ b/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.html
@@ -35,7 +35,10 @@
                      (reponseEtudiantForm.get('reponse' + question.controlName)?.value === true)">
                         <div class="mb-2"><b>{{question.bisQuestionTrue}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestionFalse &&
@@ -43,7 +46,10 @@
                      (reponseEtudiantForm.get('reponse' + question.controlName)?.value === false)">
                         <div class="mb-2"><b>{{question.bisQuestionFalse}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -59,13 +65,19 @@
                      (reponseEtudiantForm.get('reponse' + question.controlName)?.value >= 3)">
                         <div class="mb-2"><b>{{question.bisQuestionLowNotation}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestion">
                         <div class="mb-2"><b>{{question.bisQuestion}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -89,7 +101,10 @@
                       <div class="col-md-12">
                         <div class="mb-2"><b>{{question.title}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName)" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -128,7 +143,10 @@
                     <div class="mt-2 mb-2" *ngFor="let questionSupplementaire of questionsSupplementaires[0]">
                       <div class="mb-2"><b>{{questionSupplementaire.question}}</b></div>
                       <mat-form-field style="width: 100%" *ngIf="questionSupplementaire.typeQuestion == 'txt'" appearance="fill">
-                        <textarea matInput formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <mat-hint *ngIf="isLongTextLimitReached(questionSupplementaire.formControlName)" style="color:var(--dangerColor);">
+                          Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                        </mat-hint>
                       </mat-form-field>
                       <mat-radio-group *ngIf="questionSupplementaire.typeQuestion == 'not'" style="display: grid" formControlName="{{questionSupplementaire.formControlName}}">
                         <mat-radio-button style="margin-left: 0px" [value]="0">Excellent</mat-radio-button>
@@ -164,7 +182,10 @@
                      (reponseEtudiantForm.get('reponse' + question.controlName)?.value === true)">
                         <div class="mb-2"><b>{{question.bisQuestionTrue}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestionFalse &&
@@ -172,7 +193,10 @@
                      (reponseEtudiantForm.get('reponse' + question.controlName)?.value === false)">
                         <div class="mb-2"><b>{{question.bisQuestionFalse}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -188,13 +212,19 @@
                      (reponseEtudiantForm.get('reponse' + question.controlName)?.value >= 3)">
                         <div class="mb-2"><b>{{question.bisQuestionLowNotation}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestion">
                         <div class="mb-2"><b>{{question.bisQuestion}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -218,7 +248,10 @@
                       <div class="col-md-12">
                         <div class="mb-2"><b>{{question.title}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName)" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -250,7 +283,10 @@
                     <div class="mt-2 mb-2" *ngFor="let questionSupplementaire of questionsSupplementaires[1]">
                       <div class="mb-2"><b>{{questionSupplementaire.question}}</b></div>
                       <mat-form-field style="width: 100%" *ngIf="questionSupplementaire.typeQuestion == 'txt'" appearance="fill">
-                        <textarea matInput formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <mat-hint *ngIf="isLongTextLimitReached(questionSupplementaire.formControlName)" style="color:var(--dangerColor);">
+                          Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                        </mat-hint>
                       </mat-form-field>
                       <mat-radio-group *ngIf="questionSupplementaire.typeQuestion == 'not'" style="display: grid" formControlName="{{questionSupplementaire.formControlName}}">
                         <mat-radio-button style="margin-left: 0px" [value]="0">Excellent</mat-radio-button>
@@ -286,7 +322,10 @@
                      (reponseEtudiantForm.get('reponse' + question.controlName)?.value === true)">
                         <div class="mb-2"><b>{{question.bisQuestionTrue}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestionFalse &&
@@ -294,7 +333,10 @@
                      (reponseEtudiantForm.get('reponse' + question.controlName)?.value === false)">
                         <div class="mb-2"><b>{{question.bisQuestionFalse}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -310,13 +352,19 @@
                      (reponseEtudiantForm.get('reponse' + question.controlName)?.value >= 3)">
                         <div class="mb-2"><b>{{question.bisQuestionLowNotation}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestion">
                         <div class="mb-2"><b>{{question.bisQuestion}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -340,7 +388,10 @@
                       <div class="col-md-12">
                         <div class="mb-2"><b>{{question.title}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName)" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -363,7 +414,10 @@
                      (reponseEtudiantForm.get('reponse' + question.controlName)?.value === true)">
                         <div class="mb-2"><b>{{question.bisQuestionTrue}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -375,7 +429,10 @@
                     <div class="mt-2 mb-2" *ngFor="let questionSupplementaire of questionsSupplementaires[2]">
                       <div class="mb-2"><b>{{questionSupplementaire.question}}</b></div>
                       <mat-form-field style="width: 100%" *ngIf="questionSupplementaire.typeQuestion == 'txt'" appearance="fill">
-                        <textarea matInput formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <mat-hint *ngIf="isLongTextLimitReached(questionSupplementaire.formControlName)" style="color:var(--dangerColor);">
+                          Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                        </mat-hint>
                       </mat-form-field>
                       <mat-radio-group *ngIf="questionSupplementaire.typeQuestion == 'not'" style="display: grid" formControlName="{{questionSupplementaire.formControlName}}">
                         <mat-radio-button style="margin-left: 0px" [value]="0">Excellent</mat-radio-button>
@@ -454,7 +511,10 @@
                      (reponseEnseignantForm.get('reponse' + question.controlName)?.value === true)">
                         <div class="mb-2"><b>{{question.bisQuestionTrue}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestionFalse &&
@@ -462,7 +522,10 @@
                      (reponseEnseignantForm.get('reponse' + question.controlName)?.value === false)">
                         <div class="mb-2"><b>{{question.bisQuestionFalse}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -478,13 +541,19 @@
                      (reponseEnseignantForm.get('reponse' + question.controlName)?.value >= 3)">
                         <div class="mb-2"><b>{{question.bisQuestionLowNotation}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestion">
                         <div class="mb-2"><b>{{question.bisQuestion}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -508,7 +577,10 @@
                       <div class="col-md-12">
                         <div class="mb-2"><b>{{question.title}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName)" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -520,7 +592,10 @@
                     <div class="mt-2 mb-2" *ngFor="let questionSupplementaire of questionsSupplementaires[3]">
                       <div class="mb-2"><b>{{questionSupplementaire.question}}</b></div>
                       <mat-form-field style="width: 100%" *ngIf="questionSupplementaire.typeQuestion == 'txt'" appearance="fill">
-                        <textarea matInput formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <mat-hint *ngIf="isLongTextLimitReached(questionSupplementaire.formControlName)" style="color:var(--dangerColor);">
+                          Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                        </mat-hint>
                       </mat-form-field>
                       <mat-radio-group *ngIf="questionSupplementaire.typeQuestion == 'not'" style="display: grid" formControlName="{{questionSupplementaire.formControlName}}">
                         <mat-radio-button style="margin-left: 0px" [value]="0">Excellent</mat-radio-button>
@@ -556,7 +631,10 @@
                      (reponseEnseignantForm.get('reponse' + question.controlName)?.value === true)">
                         <div class="mb-2"><b>{{question.bisQuestionTrue}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestionFalse &&
@@ -564,7 +642,10 @@
                      (reponseEnseignantForm.get('reponse' + question.controlName)?.value === false)">
                         <div class="mb-2"><b>{{question.bisQuestionFalse}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -580,13 +661,19 @@
                      (reponseEnseignantForm.get('reponse' + question.controlName)?.value >= 3)">
                         <div class="mb-2"><b>{{question.bisQuestionLowNotation}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestion">
                         <div class="mb-2"><b>{{question.bisQuestion}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -610,7 +697,10 @@
                       <div class="col-md-12">
                         <div class="mb-2"><b>{{question.title}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName)" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -622,7 +712,10 @@
                     <div class="mt-2 mb-2" *ngFor="let questionSupplementaire of questionsSupplementaires[4]">
                       <div class="mb-2"><b>{{questionSupplementaire.question}}</b></div>
                       <mat-form-field style="width: 100%" *ngIf="questionSupplementaire.typeQuestion == 'txt'" appearance="fill">
-                        <textarea matInput formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <mat-hint *ngIf="isLongTextLimitReached(questionSupplementaire.formControlName)" style="color:var(--dangerColor);">
+                          Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                        </mat-hint>
                       </mat-form-field>
                       <mat-radio-group *ngIf="questionSupplementaire.typeQuestion == 'not'" style="display: grid" formControlName="{{questionSupplementaire.formControlName}}">
                         <mat-radio-button style="margin-left: 0px" [value]="0">Excellent</mat-radio-button>
@@ -701,7 +794,10 @@
                      (reponseEntrepriseForm.get('reponse' + question.controlName)?.value === true)">
                         <div class="mb-2"><b>{{question.bisQuestionTrue}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestionFalse &&
@@ -709,7 +805,10 @@
                      (reponseEntrepriseForm.get('reponse' + question.controlName)?.value === false)">
                         <div class="mb-2"><b>{{question.bisQuestionFalse}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -725,13 +824,19 @@
                      (reponseEntrepriseForm.get('reponse' + question.controlName)?.value >= 3)">
                         <div class="mb-2"><b>{{question.bisQuestionLowNotation}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestion">
                         <div class="mb-2"><b>{{question.bisQuestion}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -755,7 +860,10 @@
                       <div class="col-md-12">
                         <div class="mb-2"><b>{{question.title}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName)" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -767,7 +875,10 @@
                     <div class="mt-2 mb-2" *ngFor="let questionSupplementaire of questionsSupplementaires[5]">
                       <div class="mb-2"><b>{{questionSupplementaire.question}}</b></div>
                       <mat-form-field style="width: 100%" *ngIf="questionSupplementaire.typeQuestion == 'txt'" appearance="fill">
-                        <textarea matInput formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <mat-hint *ngIf="isLongTextLimitReached(questionSupplementaire.formControlName)" style="color:var(--dangerColor);">
+                          Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                        </mat-hint>
                       </mat-form-field>
                       <mat-radio-group *ngIf="questionSupplementaire.typeQuestion == 'not'" style="display: grid" formControlName="{{questionSupplementaire.formControlName}}">
                         <mat-radio-button style="margin-left: 0px" [value]="0">Excellent</mat-radio-button>
@@ -803,7 +914,10 @@
                      (reponseEntrepriseForm.get('reponse' + question.controlName)?.value === true)">
                         <div class="mb-2"><b>{{question.bisQuestionTrue}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestionFalse &&
@@ -811,7 +925,10 @@
                      (reponseEntrepriseForm.get('reponse' + question.controlName)?.value === false)">
                         <div class="mb-2"><b>{{question.bisQuestionFalse}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -827,13 +944,19 @@
                      (reponseEntrepriseForm.get('reponse' + question.controlName)?.value >= 3)">
                         <div class="mb-2"><b>{{question.bisQuestionLowNotation}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestion">
                         <div class="mb-2"><b>{{question.bisQuestion}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -857,7 +980,10 @@
                       <div class="col-md-12">
                         <div class="mb-2"><b>{{question.title}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName)" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -869,7 +995,10 @@
                     <div class="mt-2 mb-2" *ngFor="let questionSupplementaire of questionsSupplementaires[6]">
                       <div class="mb-2"><b>{{questionSupplementaire.question}}</b></div>
                       <mat-form-field style="width: 100%" *ngIf="questionSupplementaire.typeQuestion == 'txt'" appearance="fill">
-                        <textarea matInput formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <mat-hint *ngIf="isLongTextLimitReached(questionSupplementaire.formControlName)" style="color:var(--dangerColor);">
+                          Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                        </mat-hint>
                       </mat-form-field>
                       <mat-radio-group *ngIf="questionSupplementaire.typeQuestion == 'not'" style="display: grid" formControlName="{{questionSupplementaire.formControlName}}">
                         <mat-radio-button style="margin-left: 0px" [value]="0">Excellent</mat-radio-button>
@@ -905,7 +1034,10 @@
                      (reponseEntrepriseForm.get('reponse' + question.controlName)?.value === true)">
                         <div class="mb-2"><b>{{question.bisQuestionTrue}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestionFalse &&
@@ -913,7 +1045,10 @@
                      (reponseEntrepriseForm.get('reponse' + question.controlName)?.value === false)">
                         <div class="mb-2"><b>{{question.bisQuestionFalse}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -929,13 +1064,19 @@
                      (reponseEntrepriseForm.get('reponse' + question.controlName)?.value >= 3)">
                         <div class="mb-2"><b>{{question.bisQuestionLowNotation}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                       <div class="col-md-12 mt-2 mb-2" *ngIf="question.bisQuestion">
                         <div class="mb-2"><b>{{question.bisQuestion}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName + 'bis'}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName + 'bis')" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -959,7 +1100,10 @@
                       <div class="col-md-12">
                         <div class="mb-2"><b>{{question.title}}</b></div>
                         <mat-form-field style="width: 100%" appearance="fill">
-                          <textarea matInput formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{'reponse' + question.controlName}}"></textarea>
+                          <mat-hint *ngIf="isLongTextLimitReached('reponse' + question.controlName)" style="color:var(--dangerColor);">
+                            Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                          </mat-hint>
                         </mat-form-field>
                       </div>
                     </div>
@@ -971,7 +1115,10 @@
                     <div class="mt-2 mb-2" *ngFor="let questionSupplementaire of questionsSupplementaires[7]">
                       <div class="mb-2"><b>{{questionSupplementaire.question}}</b></div>
                       <mat-form-field style="width: 100%" *ngIf="questionSupplementaire.typeQuestion == 'txt'" appearance="fill">
-                        <textarea matInput formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <textarea matInput maxlength="{{ MAX_LENTGH_INPUT.longText }}" formControlName="{{questionSupplementaire.formControlName}}"></textarea>
+                        <mat-hint *ngIf="isLongTextLimitReached(questionSupplementaire.formControlName)" style="color:var(--dangerColor);">
+                          Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
+                        </mat-hint>
                       </mat-form-field>
                       <mat-radio-group *ngIf="questionSupplementaire.typeQuestion == 'not'" style="display: grid" formControlName="{{questionSupplementaire.formControlName}}">
                         <mat-radio-button style="margin-left: 0px" [value]="0">Excellent</mat-radio-button>

--- a/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.ts
+++ b/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.ts
@@ -6,6 +6,7 @@ import { MessageService } from "../../../services/message.service";
 import { MatExpansionPanel } from "@angular/material/expansion";
 import { AuthService } from "../../../services/auth.service";
 import * as FileSaver from 'file-saver';
+import { MAX_LENTGH_INPUT } from "../../../constants/max-length-input";
 
 @Component({
   selector: 'app-evaluation-stage',
@@ -13,7 +14,42 @@ import * as FileSaver from 'file-saver';
   styleUrls: ['./evaluation-stage.component.scss']
 })
 export class EvaluationStageComponent implements OnInit {
-
+  readonly MAX_LENTGH_INPUT = MAX_LENTGH_INPUT;
+  readonly LONG_TEXT_FIELDS:Set<string> = new Set([
+    'reponseEtuI1bis',
+    'reponseEtuII1bis',
+    'reponseEtuII2bis',
+    'reponseEtuII3bis',
+    'reponseEtuIII1bis',
+    'reponseEtuIII2bis',
+    'reponseEtuIII5bis',
+    'reponseEtuIII6bis',
+    'reponseEtuIII7bis',
+    'reponseEtuIII8bis',
+    'reponseEtuIII9bis',
+    'reponseEtuIII15bis',
+    'reponseEtuIII16bis',
+    'reponseEnsI3',
+    'reponseEnsII11',
+    'reponseEnt1bis',
+    'reponseEnt2bis',
+    'reponseEnt4bis',
+    'reponseEnt5bis',
+    'reponseEnt6bis',
+    'reponseEnt7bis',
+    'reponseEnt8bis',
+    'reponseEnt9bis',
+    'reponseEnt10bis',
+    'reponseEnt11bis',
+    'reponseEnt12bis',
+    'reponseEnt13bis',
+    'reponseEnt14bis',
+    'reponseEnt15bis',
+    'reponseEnt16bis',
+    'reponseEnt17bis',
+    'reponseEnt18bis',
+    'reponseEnt19',
+  ]);
   ficheEvaluation: any;
   reponseEvaluation: any;
   questionsSupplementaires: any;
@@ -755,7 +791,7 @@ export class EvaluationStageComponent implements OnInit {
   ) {
     this.reponseEtudiantForm = this.fb.group({
       reponseEtuI1: [null, [Validators.required]],
-      reponseEtuI1bis: [null],
+      reponseEtuI1bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEtuI2: [null, [Validators.required]],
       reponseEtuI3: [null, [Validators.required]],
       reponseEtuI4a: [null, [Validators.required]],
@@ -771,41 +807,41 @@ export class EvaluationStageComponent implements OnInit {
       reponseEtuI7bis2: [null],
       reponseEtuI8: [null, [Validators.required]],
       reponseEtuII1: [null, [Validators.required]],
-      reponseEtuII1bis: [null],
+      reponseEtuII1bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEtuII2: [null, [Validators.required]],
-      reponseEtuII2bis: [null],
+      reponseEtuII2bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEtuII3: [null, [Validators.required]],
-      reponseEtuII3bis: [null],
+      reponseEtuII3bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEtuII4: [null, [Validators.required]],
       reponseEtuII5: [null, [Validators.required]],
       reponseEtuII5a: [null],
       reponseEtuII5b: [null],
       reponseEtuII6: [null, [Validators.required]],
       reponseEtuIII1: [null, [Validators.required]],
-      reponseEtuIII1bis: [null],
+      reponseEtuIII1bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEtuIII2: [null, [Validators.required]],
-      reponseEtuIII2bis: [null],
+      reponseEtuIII2bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEtuIII4: [null, [Validators.required]],
       reponseEtuIII5a: [null, [Validators.required]],
       reponseEtuIII5b: [null, [Validators.required]],
       reponseEtuIII5c: [null, [Validators.required]],
-      reponseEtuIII5bis: [null],
+      reponseEtuIII5bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEtuIII6: [null, [Validators.required]],
-      reponseEtuIII6bis: [null],
+      reponseEtuIII6bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEtuIII7: [null, [Validators.required]],
-      reponseEtuIII7bis: [null],
+      reponseEtuIII7bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEtuIII8: [null, [Validators.required]],
-      reponseEtuIII8bis: [null],
+      reponseEtuIII8bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEtuIII9: [null, [Validators.required]],
-      reponseEtuIII9bis: [null],
+      reponseEtuIII9bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEtuIII10: [null, [Validators.required]],
       reponseEtuIII11: [null, [Validators.required]],
       reponseEtuIII12: [null, [Validators.required]],
       reponseEtuIII14: [null, [Validators.required]],
       reponseEtuIII15: [null, [Validators.required]],
-      reponseEtuIII15bis: [null],
+      reponseEtuIII15bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEtuIII16: [null, [Validators.required]],
-      reponseEtuIII16bis: [null, [Validators.required]],
+      reponseEtuIII16bis: [null, [Validators.required, Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
     });
 
     this.reponseEnseignantForm = this.fb.group({
@@ -815,7 +851,7 @@ export class EvaluationStageComponent implements OnInit {
       reponseEnsI2a: [null, [Validators.required]],
       reponseEnsI2b: [null, [Validators.required]],
       reponseEnsI2c: [null, [Validators.required]],
-      reponseEnsI3: [null, [Validators.required]],
+      reponseEnsI3: [null, [Validators.required, Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnsII1: [null, [Validators.required]],
       reponseEnsII2: [null, [Validators.required]],
       reponseEnsII3: [null, [Validators.required]],
@@ -826,46 +862,46 @@ export class EvaluationStageComponent implements OnInit {
       reponseEnsII8: [null, [Validators.required]],
       reponseEnsII9: [null, [Validators.required]],
       reponseEnsII10: [null, [Validators.required]],
-      reponseEnsII11: [null, [Validators.required]],
+      reponseEnsII11: [null, [Validators.required, Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
     });
 
     this.reponseEntrepriseForm = this.fb.group({
       reponseEnt1: [null, [Validators.required]],
-      reponseEnt1bis: [null],
+      reponseEnt1bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt2: [null, [Validators.required]],
-      reponseEnt2bis: [null],
+      reponseEnt2bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt3: [null, [Validators.required]],
       reponseEnt4: [null, [Validators.required]],
-      reponseEnt4bis: [null],
+      reponseEnt4bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt5: [null, [Validators.required]],
-      reponseEnt5bis: [null],
+      reponseEnt5bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt6: [null, [Validators.required]],
-      reponseEnt6bis: [null],
+      reponseEnt6bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt7: [null, [Validators.required]],
-      reponseEnt7bis: [null],
+      reponseEnt7bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt8: [null, [Validators.required]],
-      reponseEnt8bis: [null],
+      reponseEnt8bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt9: [null, [Validators.required]],
-      reponseEnt9bis: [null],
+      reponseEnt9bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt10: [null, [Validators.required]],
-      reponseEnt10bis: [null],
+      reponseEnt10bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt11: [null, [Validators.required]],
-      reponseEnt11bis: [null],
+      reponseEnt11bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt12: [null, [Validators.required]],
-      reponseEnt12bis: [null],
+      reponseEnt12bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt13: [null, [Validators.required]],
-      reponseEnt13bis: [null],
+      reponseEnt13bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt14: [null, [Validators.required]],
-      reponseEnt14bis: [null],
+      reponseEnt14bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt15: [null, [Validators.required]],
-      reponseEnt15bis: [null],
+      reponseEnt15bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt16: [null, [Validators.required]],
-      reponseEnt16bis: [null],
+      reponseEnt16bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt17: [null, [Validators.required]],
-      reponseEnt17bis: [null],
+      reponseEnt17bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
       reponseEnt18: [null, [Validators.required]],
-      reponseEnt18bis: [null],
-      reponseEnt19: [null, [Validators.required]],
+      reponseEnt18bis: [null, [Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
+      reponseEnt19: [null, [Validators.required, Validators.maxLength(MAX_LENTGH_INPUT.longText)]],
     });
 
     //gestion des champs required conditionnels
@@ -949,9 +985,17 @@ export class EvaluationStageComponent implements OnInit {
       const control = form.get(key);
       if (control) {
         if (toggle) {
-          control.addValidators(Validators.required);
+          if (this.LONG_TEXT_FIELDS.has(key)) {
+            control.setValidators([Validators.required, Validators.maxLength(MAX_LENTGH_INPUT.longText)]);
+          } else {
+            control.setValidators([Validators.required]);
+          }
         } else {
-          control.clearValidators();
+          if (this.LONG_TEXT_FIELDS.has(key)) {
+            control.setValidators([Validators.maxLength(MAX_LENTGH_INPUT.longText)]);
+          } else {
+            control.clearValidators();
+          }
         }
         control.updateValueAndValidity();
       }
@@ -1172,7 +1216,15 @@ export class EvaluationStageComponent implements OnInit {
           form = this.reponseSupplementaireEntrepriseForm;
         }
         const questionSupplementaireFormControlName = 'questionSupplementaire' + questionSupplementaire.id
-        form.addControl(questionSupplementaireFormControlName,new FormControl(null, Validators.required));
+        form.addControl(
+          questionSupplementaireFormControlName,
+          new FormControl(
+            null,
+            questionSupplementaire.typeQuestion == 'txt'
+              ? [Validators.required, Validators.maxLength(MAX_LENTGH_INPUT.longText)]
+              : Validators.required
+          )
+        );
         questionSupplementaire.formControlName = questionSupplementaireFormControlName
 
          if(this.reponseEvaluation){
@@ -1588,6 +1640,20 @@ export class EvaluationStageComponent implements OnInit {
     return hasBase || hasSup;
   }
 
+  getLongTextControl(name: string) {
+    return [
+      this.reponseEtudiantForm,
+      this.reponseEnseignantForm,
+      this.reponseEntrepriseForm,
+      this.reponseSupplementaireEtudiantForm,
+      this.reponseSupplementaireEnseignantForm,
+      this.reponseSupplementaireEntrepriseForm,
+    ].map(form => form?.get(name)).find(control => !!control) ?? null;
+  }
+
+  isLongTextLimitReached(name: string): boolean {
+    const value = this.getLongTextControl(name)?.value;
+    return typeof value === 'string' && value.length >= this.MAX_LENTGH_INPUT.longText;
+  }
 
 }
-

--- a/src/frontend/src/app/components/convention/stage/stage.component.html
+++ b/src/frontend/src/app/components/convention/stage/stage.component.html
@@ -30,7 +30,7 @@
           <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
             <mat-label>Sujet</mat-label>
             <textarea matInput formControlName="sujetStage" maxlength="{{ MAX_LENTGH_INPUT.longText }}" [required]="!enMasse"></textarea>
-            <mat-hint *ngIf="isLongTextLimitReached('sujetStage')" style="color:#c62828;">
+            <mat-hint *ngIf="isLongTextLimitReached('sujetStage')" style="color:var(--dangerColor);">
               Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
             </mat-hint>
             <mat-error><app-form-error [field]="form.get('sujetStage')"></app-form-error></mat-error>
@@ -87,7 +87,7 @@
           <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
             <mat-label>Détails</mat-label>
             <textarea matInput formControlName="details" maxlength="{{ MAX_LENTGH_INPUT.longText }}"></textarea>
-            <mat-hint *ngIf="isLongTextLimitReached('details')" style="color:#c62828;">
+            <mat-hint *ngIf="isLongTextLimitReached('details')" style="color:var(--dangerColor);">
               Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
             </mat-hint>
             <mat-error><app-form-error [field]="form.get('details')"></app-form-error></mat-error>
@@ -257,7 +257,7 @@
           <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
             <mat-label>Commentaire sur le temps de travail</mat-label>
             <textarea matInput formControlName="commentaireDureeTravail" maxlength="{{ MAX_LENTGH_INPUT.longText }}"></textarea>
-            <mat-hint *ngIf="isLongTextLimitReached('commentaireDureeTravail')" style="color:#c62828;">
+            <mat-hint *ngIf="isLongTextLimitReached('commentaireDureeTravail')" style="color:var(--dangerColor);">
               Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
             </mat-hint>
             <mat-error><app-form-error [field]="form.get('commentaireDureeTravail')"></app-form-error></mat-error>
@@ -359,7 +359,7 @@
             <mat-form-field class="col-12 mb-2" appearance="fill">
               <mat-label>Modalité de suivi du stagiaire</mat-label>
               <textarea matInput formControlName="modeEncadreSuivi" maxlength="{{ MAX_LENTGH_INPUT.longText }}"></textarea>
-              <mat-hint *ngIf="isLongTextLimitReached('modeEncadreSuivi')" style="color:#c62828;">
+              <mat-hint *ngIf="isLongTextLimitReached('modeEncadreSuivi')" style="color:var(--dangerColor);">
                 Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
               </mat-hint>
               <mat-error><app-form-error [field]="form.get('modeEncadreSuivi')"></app-form-error></mat-error>
@@ -367,7 +367,7 @@
             <mat-form-field class="col-12 mb-2" appearance="fill">
               <mat-label>Liste des avantages en nature</mat-label>
               <textarea matInput formControlName="avantagesNature" maxlength="{{ MAX_LENTGH_INPUT.longText }}"></textarea>
-              <mat-hint *ngIf="isLongTextLimitReached('avantagesNature')" style="color:#c62828;">
+              <mat-hint *ngIf="isLongTextLimitReached('avantagesNature')" style="color:var(--dangerColor);">
                 Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
               </mat-hint>
               <mat-error><app-form-error [field]="form.get('avantagesNature')"></app-form-error></mat-error>
@@ -376,7 +376,7 @@
             <mat-form-field class="col-12 mb-2" appearance="fill">
               <mat-label>Travail exceptionnel</mat-label>
               <textarea matInput formControlName="travailNuitFerie" maxlength="{{ MAX_LENTGH_INPUT.longText }}"></textarea>
-              <mat-hint *ngIf="isLongTextLimitReached('travailNuitFerie')" style="color:#c62828;">
+              <mat-hint *ngIf="isLongTextLimitReached('travailNuitFerie')" style="color:var(--dangerColor);">
                 Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
               </mat-hint>
               <mat-hint>Si le stagiaire doit télétravailler, être présent la nuit, le dimanche ou un jour férié, préciser</mat-hint>
@@ -390,7 +390,7 @@
           <mat-form-field class="col-6 mb-2" appearance="fill">
             <mat-label>Modalité de suivi du stagiaire</mat-label>
             <textarea matInput formControlName="modeEncadreSuivi" maxlength="{{ MAX_LENTGH_INPUT.longText }}"></textarea>
-            <mat-hint *ngIf="isLongTextLimitReached('modeEncadreSuivi')" style="color:#c62828;">
+            <mat-hint *ngIf="isLongTextLimitReached('modeEncadreSuivi')" style="color:var(--dangerColor);">
               Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
             </mat-hint>
             <mat-error><app-form-error [field]="form.get('modeEncadreSuivi')"></app-form-error></mat-error>

--- a/src/frontend/src/app/components/convention/stage/stage.component.html
+++ b/src/frontend/src/app/components/convention/stage/stage.component.html
@@ -29,7 +29,10 @@
         <div class="row">
           <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
             <mat-label>Sujet</mat-label>
-            <textarea matInput formControlName="sujetStage" [required]="!enMasse"></textarea>
+            <textarea matInput formControlName="sujetStage" maxlength="{{ MAX.longText }}" [required]="!enMasse"></textarea>
+            <mat-hint *ngIf="isLongTextLimitReached('sujetStage')" style="color:#c62828;">
+              Limite de {{ MAX.longText }} caractères atteinte
+            </mat-hint>
             <mat-error><app-form-error [field]="form.get('sujetStage')"></app-form-error></mat-error>
           </mat-form-field>
 
@@ -83,8 +86,11 @@
 
           <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
             <mat-label>Détails</mat-label>
-            <textarea matInput formControlName="details"></textarea>
-            <mat-error><app-form-error [field]="form.get('sujet')"></app-form-error></mat-error>
+            <textarea matInput formControlName="details" maxlength="{{ MAX.longText }}"></textarea>
+            <mat-hint *ngIf="isLongTextLimitReached('details')" style="color:#c62828;">
+              Limite de {{ MAX.longText }} caractères atteinte
+            </mat-hint>
+            <mat-error><app-form-error [field]="form.get('details')"></app-form-error></mat-error>
           </mat-form-field>
         </div>
 
@@ -165,8 +171,15 @@
           </mat-form-field>
           <mat-form-field class="col-sm-6 col-md-6 mb-2" appearance="fill">
             <mat-label>Nombre de jours de congés autorisés</mat-label>
-            <input type="text" step="any" matInput formControlName="nbConges" />
+            <input type="text" step="any" maxlength="{{MAX.nbConges}}"  matInput formControlName="nbConges" (focus)="focused = 'nbConges'" (blur)="focused = focused === 'nbConges' ? null : focused"/>
             <mat-hint>ou modalités des congés et autorisations d'absence durant le stage</mat-hint>
+            <mat-hint
+              align="end"
+              *ngIf="!hasError('nbConges') && focused === 'nbConges'"
+              [ngStyle]="{ color: counterColor('nbConges') }"
+            >
+              {{ len('nbConges') }}/{{ MAX.nbConges }}
+            </mat-hint>
             <mat-error><app-form-error [field]="form.get('nbConges')"></app-form-error></mat-error>
           </mat-form-field>
         </div>
@@ -243,7 +256,10 @@
           </mat-form-field>
           <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
             <mat-label>Commentaire sur le temps de travail</mat-label>
-            <textarea matInput formControlName="commentaireDureeTravail"></textarea>
+            <textarea matInput formControlName="commentaireDureeTravail" maxlength="{{ MAX.longText }}"></textarea>
+            <mat-hint *ngIf="isLongTextLimitReached('commentaireDureeTravail')" style="color:#c62828;">
+              Limite de {{ MAX.longText }} caractères atteinte
+            </mat-hint>
             <mat-error><app-form-error [field]="form.get('commentaireDureeTravail')"></app-form-error></mat-error>
           </mat-form-field>
 
@@ -342,18 +358,27 @@
           <div class="row col-sm-12 col-md-6">
             <mat-form-field class="col-12 mb-2" appearance="fill">
               <mat-label>Modalité de suivi du stagiaire</mat-label>
-              <textarea matInput formControlName="modeEncadreSuivi"></textarea>
+              <textarea matInput formControlName="modeEncadreSuivi" maxlength="{{ MAX.longText }}"></textarea>
+              <mat-hint *ngIf="isLongTextLimitReached('modeEncadreSuivi')" style="color:#c62828;">
+                Limite de {{ MAX.longText }} caractères atteinte
+              </mat-hint>
               <mat-error><app-form-error [field]="form.get('modeEncadreSuivi')"></app-form-error></mat-error>
             </mat-form-field>
             <mat-form-field class="col-12 mb-2" appearance="fill">
               <mat-label>Liste des avantages en nature</mat-label>
-              <textarea matInput formControlName="avantagesNature"></textarea>
+              <textarea matInput formControlName="avantagesNature" maxlength="{{ MAX.longText }}"></textarea>
+              <mat-hint *ngIf="isLongTextLimitReached('avantagesNature')" style="color:#c62828;">
+                Limite de {{ MAX.longText }} caractères atteinte
+              </mat-hint>
               <mat-error><app-form-error [field]="form.get('avantagesNature')"></app-form-error></mat-error>
             </mat-form-field>
 
             <mat-form-field class="col-12 mb-2" appearance="fill">
               <mat-label>Travail exceptionnel</mat-label>
-              <textarea matInput formControlName="travailNuitFerie"></textarea>
+              <textarea matInput formControlName="travailNuitFerie" maxlength="{{ MAX.longText }}"></textarea>
+              <mat-hint *ngIf="isLongTextLimitReached('travailNuitFerie')" style="color:#c62828;">
+                Limite de {{ MAX.longText }} caractères atteinte
+              </mat-hint>
               <mat-hint>Si le stagiaire doit télétravailler, être présent la nuit, le dimanche ou un jour férié, préciser</mat-hint>
               <mat-error><app-form-error [field]="form.get('travailNuitFerie')"></app-form-error></mat-error>
             </mat-form-field>
@@ -364,7 +389,10 @@
         <div class="row" *ngIf="enMasse">
           <mat-form-field class="col-6 mb-2" appearance="fill">
             <mat-label>Modalité de suivi du stagiaire</mat-label>
-            <textarea matInput formControlName="modeEncadreSuivi"></textarea>
+            <textarea matInput formControlName="modeEncadreSuivi" maxlength="{{ MAX.longText }}"></textarea>
+            <mat-hint *ngIf="isLongTextLimitReached('modeEncadreSuivi')" style="color:#c62828;">
+              Limite de {{ MAX.longText }} caractères atteinte
+            </mat-hint>
             <mat-error><app-form-error [field]="form.get('modeEncadreSuivi')"></app-form-error></mat-error>
           </mat-form-field>
         </div>

--- a/src/frontend/src/app/components/convention/stage/stage.component.html
+++ b/src/frontend/src/app/components/convention/stage/stage.component.html
@@ -29,9 +29,9 @@
         <div class="row">
           <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
             <mat-label>Sujet</mat-label>
-            <textarea matInput formControlName="sujetStage" maxlength="{{ MAX.longText }}" [required]="!enMasse"></textarea>
+            <textarea matInput formControlName="sujetStage" maxlength="{{ MAX_LENTGH_INPUT.longText }}" [required]="!enMasse"></textarea>
             <mat-hint *ngIf="isLongTextLimitReached('sujetStage')" style="color:#c62828;">
-              Limite de {{ MAX.longText }} caractères atteinte
+              Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
             </mat-hint>
             <mat-error><app-form-error [field]="form.get('sujetStage')"></app-form-error></mat-error>
           </mat-form-field>
@@ -41,7 +41,7 @@
             <textarea
               matInput
               formControlName="competences"
-              maxlength="{{ MAX.competences }}"
+              maxlength="{{ MAX_LENTGH_INPUT.competences }}"
               [required]="!enMasse"
               (focus)="focused = 'competences'"
               (blur)="focused = focused === 'competences' ? null : focused"
@@ -56,7 +56,7 @@
               *ngIf="!hasError('competences') && focused === 'competences'"
               [ngStyle]="{ color: counterColor('competences') }"
             >
-              {{ len('competences') }}/{{ MAX.competences }}
+              {{ len('competences') }}/{{ MAX_LENTGH_INPUT.competences }}
             </mat-hint>
           </mat-form-field>
 
@@ -65,7 +65,7 @@
             <textarea
               matInput
               formControlName="fonctionsEtTaches"
-              maxlength="{{ MAX.fonctionsEtTaches }}"
+              maxlength="{{ MAX_LENTGH_INPUT.fonctionsEtTaches }}"
               [required]="!enMasse"
               (focus)="focused = 'fonctionsEtTaches'"
               (blur)="focused = focused === 'fonctionsEtTaches' ? null : focused"
@@ -80,15 +80,15 @@
               *ngIf="!hasError('fonctionsEtTaches') && focused === 'fonctionsEtTaches'"
               [ngStyle]="{ color: counterColor('fonctionsEtTaches') }"
             >
-              {{ len('fonctionsEtTaches') }}/{{ MAX.fonctionsEtTaches }}
+              {{ len('fonctionsEtTaches') }}/{{ MAX_LENTGH_INPUT.fonctionsEtTaches }}
             </mat-hint>
           </mat-form-field>
 
           <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
             <mat-label>Détails</mat-label>
-            <textarea matInput formControlName="details" maxlength="{{ MAX.longText }}"></textarea>
+            <textarea matInput formControlName="details" maxlength="{{ MAX_LENTGH_INPUT.longText }}"></textarea>
             <mat-hint *ngIf="isLongTextLimitReached('details')" style="color:#c62828;">
-              Limite de {{ MAX.longText }} caractères atteinte
+              Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
             </mat-hint>
             <mat-error><app-form-error [field]="form.get('details')"></app-form-error></mat-error>
           </mat-form-field>
@@ -171,14 +171,14 @@
           </mat-form-field>
           <mat-form-field class="col-sm-6 col-md-6 mb-2" appearance="fill">
             <mat-label>Nombre de jours de congés autorisés</mat-label>
-            <input type="text" step="any" maxlength="{{MAX.nbConges}}"  matInput formControlName="nbConges" (focus)="focused = 'nbConges'" (blur)="focused = focused === 'nbConges' ? null : focused"/>
+            <input type="text" step="any" maxlength="{{MAX_LENTGH_INPUT.nbConges}}"  matInput formControlName="nbConges" (focus)="focused = 'nbConges'" (blur)="focused = focused === 'nbConges' ? null : focused"/>
             <mat-hint>ou modalités des congés et autorisations d'absence durant le stage</mat-hint>
             <mat-hint
               align="end"
               *ngIf="!hasError('nbConges') && focused === 'nbConges'"
               [ngStyle]="{ color: counterColor('nbConges') }"
             >
-              {{ len('nbConges') }}/{{ MAX.nbConges }}
+              {{ len('nbConges') }}/{{ MAX_LENTGH_INPUT.nbConges }}
             </mat-hint>
             <mat-error><app-form-error [field]="form.get('nbConges')"></app-form-error></mat-error>
           </mat-form-field>
@@ -256,9 +256,9 @@
           </mat-form-field>
           <mat-form-field class="col-sm-12 col-md-6 mb-2" appearance="fill">
             <mat-label>Commentaire sur le temps de travail</mat-label>
-            <textarea matInput formControlName="commentaireDureeTravail" maxlength="{{ MAX.longText }}"></textarea>
+            <textarea matInput formControlName="commentaireDureeTravail" maxlength="{{ MAX_LENTGH_INPUT.longText }}"></textarea>
             <mat-hint *ngIf="isLongTextLimitReached('commentaireDureeTravail')" style="color:#c62828;">
-              Limite de {{ MAX.longText }} caractères atteinte
+              Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
             </mat-hint>
             <mat-error><app-form-error [field]="form.get('commentaireDureeTravail')"></app-form-error></mat-error>
           </mat-form-field>
@@ -358,26 +358,26 @@
           <div class="row col-sm-12 col-md-6">
             <mat-form-field class="col-12 mb-2" appearance="fill">
               <mat-label>Modalité de suivi du stagiaire</mat-label>
-              <textarea matInput formControlName="modeEncadreSuivi" maxlength="{{ MAX.longText }}"></textarea>
+              <textarea matInput formControlName="modeEncadreSuivi" maxlength="{{ MAX_LENTGH_INPUT.longText }}"></textarea>
               <mat-hint *ngIf="isLongTextLimitReached('modeEncadreSuivi')" style="color:#c62828;">
-                Limite de {{ MAX.longText }} caractères atteinte
+                Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
               </mat-hint>
               <mat-error><app-form-error [field]="form.get('modeEncadreSuivi')"></app-form-error></mat-error>
             </mat-form-field>
             <mat-form-field class="col-12 mb-2" appearance="fill">
               <mat-label>Liste des avantages en nature</mat-label>
-              <textarea matInput formControlName="avantagesNature" maxlength="{{ MAX.longText }}"></textarea>
+              <textarea matInput formControlName="avantagesNature" maxlength="{{ MAX_LENTGH_INPUT.longText }}"></textarea>
               <mat-hint *ngIf="isLongTextLimitReached('avantagesNature')" style="color:#c62828;">
-                Limite de {{ MAX.longText }} caractères atteinte
+                Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
               </mat-hint>
               <mat-error><app-form-error [field]="form.get('avantagesNature')"></app-form-error></mat-error>
             </mat-form-field>
 
             <mat-form-field class="col-12 mb-2" appearance="fill">
               <mat-label>Travail exceptionnel</mat-label>
-              <textarea matInput formControlName="travailNuitFerie" maxlength="{{ MAX.longText }}"></textarea>
+              <textarea matInput formControlName="travailNuitFerie" maxlength="{{ MAX_LENTGH_INPUT.longText }}"></textarea>
               <mat-hint *ngIf="isLongTextLimitReached('travailNuitFerie')" style="color:#c62828;">
-                Limite de {{ MAX.longText }} caractères atteinte
+                Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
               </mat-hint>
               <mat-hint>Si le stagiaire doit télétravailler, être présent la nuit, le dimanche ou un jour férié, préciser</mat-hint>
               <mat-error><app-form-error [field]="form.get('travailNuitFerie')"></app-form-error></mat-error>
@@ -389,9 +389,9 @@
         <div class="row" *ngIf="enMasse">
           <mat-form-field class="col-6 mb-2" appearance="fill">
             <mat-label>Modalité de suivi du stagiaire</mat-label>
-            <textarea matInput formControlName="modeEncadreSuivi" maxlength="{{ MAX.longText }}"></textarea>
+            <textarea matInput formControlName="modeEncadreSuivi" maxlength="{{ MAX_LENTGH_INPUT.longText }}"></textarea>
             <mat-hint *ngIf="isLongTextLimitReached('modeEncadreSuivi')" style="color:#c62828;">
-              Limite de {{ MAX.longText }} caractères atteinte
+              Limite de {{ MAX_LENTGH_INPUT.longText }} caractères atteinte
             </mat-hint>
             <mat-error><app-form-error [field]="form.get('modeEncadreSuivi')"></app-form-error></mat-error>
           </mat-form-field>

--- a/src/frontend/src/app/components/convention/stage/stage.component.ts
+++ b/src/frontend/src/app/components/convention/stage/stage.component.ts
@@ -29,8 +29,10 @@ import { PeriodeStageService } from'../../../services/periode-stage.service';
 })
 export class StageComponent implements OnInit {
   readonly MAX = {
+    longText: 30000,
     competences: 1000,
     fonctionsEtTaches: 1000,
+    nbConges: 1000,
   } as const;
 
   focused: keyof typeof this.MAX | null = null;
@@ -39,9 +41,14 @@ export class StageComponent implements OnInit {
     'nbHeuresHebdo': [Validators.required, Validators.pattern('[0-9]{1,2}([,.][0-9]{1,2})?')],
     'dureeExceptionnelle': [Validators.required, Validators.pattern('[0-9]+([,.][0-9]{1,2})?')],
     'montantGratification': [Validators.required, Validators.pattern('[0-9]{1,10}([,.][0-9]{1,2})?')],
-    'sujetStage': [Validators.required],
+    'sujetStage': [Validators.required, Validators.maxLength(this.MAX.longText)],
     'competences': [Validators.required, Validators.maxLength(this.MAX.competences)],
     'fonctionsEtTaches': [Validators.required,Validators.maxLength(this.MAX.fonctionsEtTaches)],
+    'details': [Validators.maxLength(this.MAX.longText)],
+    'commentaireDureeTravail': [Validators.maxLength(this.MAX.longText)],
+    'modeEncadreSuivi': [Validators.maxLength(this.MAX.longText)],
+    'avantagesNature': [Validators.maxLength(this.MAX.longText)],
+    'travailNuitFerie': [Validators.maxLength(this.MAX.longText)],
     'idUniteGratification': [Validators.required],
     'idUniteDuree': [Validators.required],
     'idDevise': [Validators.required],
@@ -50,6 +57,7 @@ export class StageComponent implements OnInit {
     'confidentiel': [Validators.required],
     'idNatureTravail': [Validators.required],
     'idModeValidationStage': [Validators.required],
+    'nbConges': [Validators.maxLength(this.MAX.nbConges)],
   }
 
   interruptionsStageTableColumns = ['dateDebutInterruption', 'dateFinInterruption', 'actions'];
@@ -173,10 +181,10 @@ export class StageComponent implements OnInit {
       idPays: [this.convention.paysConvention ? this.convention.paysConvention.id : null, [Validators.required]],
       // - Description du stage
       idTheme: [this.convention.theme ? this.convention.theme.id : null, [Validators.required]],
-      sujetStage: [this.convention.sujetStage],
-      competences: [this.convention.competences],
-      fonctionsEtTaches: [this.convention.fonctionsEtTaches],
-      details: [this.convention.details],
+      sujetStage: [this.convention.sujetStage, this.fieldValidators['sujetStage']],
+      competences: [this.convention.competences, this.fieldValidators['competences']],
+      fonctionsEtTaches: [this.convention.fonctionsEtTaches, this.fieldValidators['fonctionsEtTaches']],
+      details: [this.convention.details, this.fieldValidators['details']],
       // - Partie Dates / horaires
       dateDebutStage: [this.convention.dateDebutStage ? new Date(this.convention.dateDebutStage) : null, [Validators.required]],
       dateFinStage: [this.convention.dateFinStage ? new Date(this.convention.dateFinStage) : null, [Validators.required]],
@@ -186,7 +194,7 @@ export class StageComponent implements OnInit {
       nbConges: [this.convention.nbConges],
       dureeExceptionnelle: [this.convention.dureeExceptionnelle, this.fieldValidators['dureeExceptionnelle']],
       idTempsTravail: [this.convention.tempsTravail ? this.convention.tempsTravail.id : null, [Validators.required]],
-      commentaireDureeTravail: [this.convention.commentaireDureeTravail],
+      commentaireDureeTravail: [this.convention.commentaireDureeTravail, this.fieldValidators['commentaireDureeTravail']],
       periodeStageMois: [this.dureeStage.dureeMois, [Validators.min(0), Validators.max(30),Validators.required]],
       periodeStageJours: [this.dureeStage.dureeJours, [Validators.min(0), Validators.max(31),Validators.required]],
       periodeStageHeures: [this.dureeStage.dureeHeures, [Validators.min(0), Validators.max(23),Validators.required]],
@@ -203,9 +211,9 @@ export class StageComponent implements OnInit {
       confidentiel: [this.convention.confidentiel],
       idNatureTravail: [this.convention.natureTravail ? this.convention.natureTravail.id : null],
       idModeValidationStage: [this.convention.modeValidationStage ? this.convention.modeValidationStage.id : null],
-      modeEncadreSuivi: [this.convention.modeEncadreSuivi],
-      avantagesNature: [this.convention.avantagesNature],
-      travailNuitFerie: [this.convention.travailNuitFerie],
+      modeEncadreSuivi: [this.convention.modeEncadreSuivi, this.fieldValidators['modeEncadreSuivi']],
+      avantagesNature: [this.convention.avantagesNature, this.fieldValidators['avantagesNature']],
+      travailNuitFerie: [this.convention.travailNuitFerie, this.fieldValidators['travailNuitFerie']],
     }, { emitEvent: false });
 
     this.form.get('periodeStageMois')!.valueChanges.subscribe(value => {
@@ -969,4 +977,12 @@ export class StageComponent implements OnInit {
     return !!(ctrl && ctrl.invalid && (ctrl.touched || ctrl.dirty));
   }
 
+  longTextLength(fieldName: string): number {
+    const value = this.form?.get(fieldName)?.value;
+    return typeof value === 'string' ? value.length : 0;
+  }
+
+  isLongTextLimitReached(fieldName: string): boolean {
+    return this.longTextLength(fieldName) >= this.MAX.longText;
+  }
 }

--- a/src/frontend/src/app/components/convention/stage/stage.component.ts
+++ b/src/frontend/src/app/components/convention/stage/stage.component.ts
@@ -21,6 +21,7 @@ import { debounceTime } from 'rxjs/operators'
 import { CalendrierComponent } from './calendrier/calendrier.component';
 import { InterruptionsFormComponent } from './interruptions-form/interruptions-form.component';
 import { PeriodeStageService } from'../../../services/periode-stage.service';
+import {MAX_LENTGH_INPUT} from "../../../constants/max-length-input";
 
 @Component({
   selector: 'app-stage',
@@ -28,27 +29,21 @@ import { PeriodeStageService } from'../../../services/periode-stage.service';
   styleUrls: ['./stage.component.scss']
 })
 export class StageComponent implements OnInit {
-  readonly MAX = {
-    longText: 30000,
-    competences: 1000,
-    fonctionsEtTaches: 1000,
-    nbConges: 1000,
-  } as const;
 
-  focused: keyof typeof this.MAX | null = null;
+  focused: keyof typeof MAX_LENTGH_INPUT | null = null;
 
   fieldValidators : any = {
     'nbHeuresHebdo': [Validators.required, Validators.pattern('[0-9]{1,2}([,.][0-9]{1,2})?')],
     'dureeExceptionnelle': [Validators.required, Validators.pattern('[0-9]+([,.][0-9]{1,2})?')],
     'montantGratification': [Validators.required, Validators.pattern('[0-9]{1,10}([,.][0-9]{1,2})?')],
-    'sujetStage': [Validators.required, Validators.maxLength(this.MAX.longText)],
-    'competences': [Validators.required, Validators.maxLength(this.MAX.competences)],
-    'fonctionsEtTaches': [Validators.required,Validators.maxLength(this.MAX.fonctionsEtTaches)],
-    'details': [Validators.maxLength(this.MAX.longText)],
-    'commentaireDureeTravail': [Validators.maxLength(this.MAX.longText)],
-    'modeEncadreSuivi': [Validators.maxLength(this.MAX.longText)],
-    'avantagesNature': [Validators.maxLength(this.MAX.longText)],
-    'travailNuitFerie': [Validators.maxLength(this.MAX.longText)],
+    'sujetStage': [Validators.required, Validators.maxLength(MAX_LENTGH_INPUT.longText)],
+    'competences': [Validators.required, Validators.maxLength(MAX_LENTGH_INPUT.competences)],
+    'fonctionsEtTaches': [Validators.required,Validators.maxLength(MAX_LENTGH_INPUT.fonctionsEtTaches)],
+    'details': [Validators.maxLength(MAX_LENTGH_INPUT.longText)],
+    'commentaireDureeTravail': [Validators.maxLength(MAX_LENTGH_INPUT.longText)],
+    'modeEncadreSuivi': [Validators.maxLength(MAX_LENTGH_INPUT.longText)],
+    'avantagesNature': [Validators.maxLength(MAX_LENTGH_INPUT.longText)],
+    'travailNuitFerie': [Validators.maxLength(MAX_LENTGH_INPUT.longText)],
     'idUniteGratification': [Validators.required],
     'idUniteDuree': [Validators.required],
     'idDevise': [Validators.required],
@@ -57,7 +52,7 @@ export class StageComponent implements OnInit {
     'confidentiel': [Validators.required],
     'idNatureTravail': [Validators.required],
     'idModeValidationStage': [Validators.required],
-    'nbConges': [Validators.maxLength(this.MAX.nbConges)],
+    'nbConges': [Validators.maxLength(MAX_LENTGH_INPUT.nbConges)],
   }
 
   interruptionsStageTableColumns = ['dateDebutInterruption', 'dateFinInterruption', 'actions'];
@@ -958,21 +953,21 @@ export class StageComponent implements OnInit {
     return Math.round((nbHeures - heuresNormales) * 100) / 100;
   }
 
-  len(name: keyof StageComponent['MAX']): number {
+  len(name: keyof typeof MAX_LENTGH_INPUT): number {
     const v = this.form.get(name)?.value as string | null;
-    return (v?.length ?? 0);
+    return v?.length ?? 0;
   }
 
-  // Couleur HSL du vert (120) au rouge (0) en fonction du ratio
-  counterColor(name: keyof StageComponent['MAX']): string {
-    const max = this.MAX[name];
+// Couleur HSL du vert (120) au rouge (0) en fonction du ratio
+  counterColor(name: keyof typeof MAX_LENTGH_INPUT): string {
+    const max = MAX_LENTGH_INPUT[name];
     const l = this.len(name);
     const ratio = Math.min(l / max, 1); // 0..1
     const hue = 120 - 120 * ratio;      // 120 → 0
     return `hsl(${hue}, 80%, 40%)`;
   }
 
-  hasError(name: keyof StageComponent['MAX']): boolean {
+  hasError(name: keyof typeof MAX_LENTGH_INPUT): boolean {
     const ctrl = this.form.get(name);
     return !!(ctrl && ctrl.invalid && (ctrl.touched || ctrl.dirty));
   }
@@ -983,6 +978,8 @@ export class StageComponent implements OnInit {
   }
 
   isLongTextLimitReached(fieldName: string): boolean {
-    return this.longTextLength(fieldName) >= this.MAX.longText;
+    return this.longTextLength(fieldName) >= MAX_LENTGH_INPUT.longText;
   }
+
+  protected readonly MAX_LENTGH_INPUT = MAX_LENTGH_INPUT;
 }

--- a/src/frontend/src/app/constants/max-length-input.ts
+++ b/src/frontend/src/app/constants/max-length-input.ts
@@ -1,0 +1,7 @@
+export const MAX_LENTGH_INPUT = {
+  longText: 30000,
+  competences: 1000,
+  fonctionsEtTaches: 1000,
+  nbConges: 1000,
+  titreAvenant: 255,
+} as const;

--- a/src/main/java/org/esup_portail/esup_stage/repository/PaginationRepository.java
+++ b/src/main/java/org/esup_portail/esup_stage/repository/PaginationRepository.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 
 public class PaginationRepository<T extends Exportable> {
 
-    private static final Logger logger = LoggerFactory.getLogger(UtilisateurRepository.class);
+    private static final Logger logger = LoggerFactory.getLogger(PaginationRepository.class);
     private static final int EXCEL_CELL_MAX_LENGTH = 30000;
 
     protected final EntityManager em;
@@ -306,17 +306,18 @@ public class PaginationRepository<T extends Exportable> {
             row = sheet.createRow(rowNum);
             for (Map.Entry<String, JsonElement> entry : entrySet) {
                 Cell cell = row.createCell(columnNum);
-                cell.setCellValue(truncateExcelCellValue(entity.getExportValue(entry.getKey())));
+                cell.setCellValue(truncateExcelCellValue(entity.getExportValue(entry.getKey()), title, entry.getKey(), rowNum));
                 columnNum++;
             }
             rowNum++;
         }
     }
 
-    private String truncateExcelCellValue(String value) {
-        if (value == null || value.length() < EXCEL_CELL_MAX_LENGTH) {
+    private String truncateExcelCellValue(String value, String sheetTitle, String fieldName, int rowNum) {
+        if (value == null || value.length() <= EXCEL_CELL_MAX_LENGTH) {
             return value;
         }
+        logger.info("Valeur tronquée lors de l'export Excel sur l'onglet '{}' pour le champ '{}' à la ligne {} : longueur initiale {}, longueur conservée {}", sheetTitle, fieldName, rowNum + 1, value.length(), EXCEL_CELL_MAX_LENGTH);
         return value.substring(0, EXCEL_CELL_MAX_LENGTH);
     }
 

--- a/src/main/java/org/esup_portail/esup_stage/repository/PaginationRepository.java
+++ b/src/main/java/org/esup_portail/esup_stage/repository/PaginationRepository.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 public class PaginationRepository<T extends Exportable> {
 
     private static final Logger logger = LoggerFactory.getLogger(UtilisateurRepository.class);
+    private static final int EXCEL_CELL_MAX_LENGTH = 30000;
 
     protected final EntityManager em;
     protected final Class<T> typeClass;
@@ -305,11 +306,18 @@ public class PaginationRepository<T extends Exportable> {
             row = sheet.createRow(rowNum);
             for (Map.Entry<String, JsonElement> entry : entrySet) {
                 Cell cell = row.createCell(columnNum);
-                cell.setCellValue(entity.getExportValue(entry.getKey()));
+                cell.setCellValue(truncateExcelCellValue(entity.getExportValue(entry.getKey())));
                 columnNum++;
             }
             rowNum++;
         }
+    }
+
+    private String truncateExcelCellValue(String value) {
+        if (value == null || value.length() < EXCEL_CELL_MAX_LENGTH) {
+            return value;
+        }
+        return value.substring(0, EXCEL_CELL_MAX_LENGTH);
     }
 
     public StringBuilder exportCsv(String headerString, String predicate, String sortOrder, String filters) {


### PR DESCRIPTION
- Correction de l’extraction Excel pour tronquer les valeurs supérieures à 30 000 caractères
- Ajout de contrôles de saisie pour empêcher la saisie de plus de 30 000 caractères

Permet d’éviter d’atteindre la limite de 32 767 caractères par cellule fixée par Excel.