### PR TITLE
Correction story #10533 et issue #524 - Chargement du champs formation

### DIFF
--- a/src/frontend/src/app/components/convention/etudiant/etudiant.component.html
+++ b/src/frontend/src/app/components/convention/etudiant/etudiant.component.html
@@ -162,19 +162,22 @@
           <div class="text-title"><i class="fa fa-graduation-cap"></i> Choisissez le cadre du stage</div>
             <mat-divider></mat-divider>
             <div class="mt-3 mb-3">
-              <ng-container *ngIf="inscriptions.length === 0; else hasInscriptions">
+              <ng-container *ngIf="inscriptions.length === 0 && (hasLoadedApogeeInscriptions || !convention.id); else hasInscriptions">
                 <div class="alert alert-danger">
                   Vous n'êtes inscrit à aucune formation éligible.
                 </div>
               </ng-container>
               <ng-template #hasInscriptions>
-                <ng-container *ngIf="inscriptions.length > 1">
+                <ng-container *ngIf="inscriptions.length > 1 || (modifiable && convention.id && !hasLoadedApogeeInscriptions && inscriptions.length > 0)">
                   <div class="row">
                     <mat-form-field class="col-sm-12 mb-2" appearance="fill">
                       <mat-label>Formation</mat-label>
-                      <mat-select formControlName="inscription" required>
-                        <mat-option *ngFor="let inscription of inscriptions" [value]="inscription">{{inscription.annee + '/' + (+inscription.annee + 1) + ': ' + inscription.etapeInscription.codeEtp + ' - ' + inscription.etapeInscription.libWebVet}}<span class="option-composante">({{inscription.etapeInscription.codeComposante}})</span></mat-option>
+                      <mat-select formControlName="inscription" required (openedChange)="loadApogeeInscriptionsOnDemand($event)">
+                        <mat-option *ngFor="let inscription of inscriptions" [value]="inscription">{{inscription.annee + '/' + (+inscription.annee + 1) + ': ' + inscription.etapeInscription.codeEtp + ' - ' + getInscriptionLibelle(inscription)}}<span class="option-composante" *ngIf="getInscriptionCodeComposante(inscription)">({{getInscriptionCodeComposante(inscription)}})</span></mat-option>
                       </mat-select>
+                      <mat-hint *ngIf="modifiable && convention.id && !hasLoadedApogeeInscriptions && !apogeeInscriptionsLoadFailed && !isLoadingApogeeInscriptions">Ouvrir la liste pour charger les autres formations et ELP.</mat-hint>
+                      <mat-hint *ngIf="isLoadingApogeeInscriptions">Chargement des formations...</mat-hint>
+                      <mat-hint *ngIf="apogeeInscriptionsLoadFailed">Le chargement a echoue. Rouvrez la liste pour reessayer.</mat-hint>
                       <mat-error><app-form-error [field]="formConvention.get('inscription')"></app-form-error></mat-error>
                     </mat-form-field>
                   </div>
@@ -186,7 +189,7 @@
                   </div>
                   <div class="row mb-2">
                     <div class="col-sm-4 font-weight-bold">Formation</div>
-                    <div class="col-sm-8">{{selectedInscription.etapeInscription.codeEtp}}{{selectedInscription.etapeInscription.libComposante != null ? ' - ' + selectedInscription.etapeInscription.libComposante : ''}}</div>
+                    <div class="col-sm-8">{{selectedInscription.etapeInscription.codeEtp}}{{getInscriptionLibelle(selectedInscription) ? ' - ' + getInscriptionLibelle(selectedInscription) : ''}}</div>
                   </div>
                   <div class="row" *ngIf="selectedInscription.elementPedagogiques.length > 0">
                     <mat-form-field class="col-sm-12 mb-2" appearance="fill">

--- a/src/frontend/src/app/components/convention/etudiant/etudiant.component.ts
+++ b/src/frontend/src/app/components/convention/etudiant/etudiant.component.ts
@@ -40,6 +40,9 @@ export class EtudiantComponent implements OnInit, OnChanges {
   centreGestion: any;
   sansElp: boolean = false;
   canEditTypeConvention: boolean = false;
+  isLoadingApogeeInscriptions: boolean = false;
+  hasLoadedApogeeInscriptions: boolean = false;
+  apogeeInscriptionsLoadFailed: boolean = false;
 
   formConvention!: FormGroup;
 
@@ -132,9 +135,13 @@ export class EtudiantComponent implements OnInit, OnChanges {
 
       this.formConvention.get('inscription')?.valueChanges.subscribe((inscription: any) => {
         if (inscription) {
+          const inscriptionElpControl = this.formConvention.get('inscriptionElp');
           if (!this.sansElp && inscription.elementPedagogiques && inscription.elementPedagogiques.length > 0) {
-            this.formConvention.get('inscriptionElp')?.setValidators([Validators.required]);
+            inscriptionElpControl?.setValidators([Validators.required]);
+          } else {
+            inscriptionElpControl?.clearValidators();
           }
+          inscriptionElpControl?.updateValueAndValidity({ emitEvent: false });
           if(!this.centreGestion){
             this.centreGestion = inscription.centreGestion;
           }
@@ -232,16 +239,16 @@ export class EtudiantComponent implements OnInit, OnChanges {
   choose(row: any): void {
     this.selectedRow = row;
     this.selectedNumEtudiant = row.codEtu;
+    this.isLoadingApogeeInscriptions = false;
+    this.hasLoadedApogeeInscriptions = false;
+    this.apogeeInscriptionsLoadFailed = false;
 
-    // Ferme le panel de recherche d'étudiant
     if (this.searchEtudiantPanel) {
       this.searchEtudiantPanel.expanded = false;
     }
 
-    // Vérifie si la convention existe déjà avec un ID
     if (this.convention && this.convention.id) {
       this.etudiant = this.convention.etudiant;
-      // Remplir le formulaire avec les valeurs de la convention
       this.formConvention.get('adresseEtudiant')?.setValue(this.convention.adresseEtudiant);
       this.formConvention.get('codePostalEtudiant')?.setValue(this.convention.codePostalEtudiant);
       this.formConvention.get('villeEtudiant')?.setValue(this.convention.villeEtudiant);
@@ -252,14 +259,10 @@ export class EtudiantComponent implements OnInit, OnChanges {
       this.centreGestion = this.convention.centreGestion;
 
       if (this.convention.etape) {
-        // Recrée un objet inscription avec les données de la convention existante
-        const annee = parseInt(this.convention.annee.split('/')[0]) ;
-
-        // Définir le tableau elementPedagogiques comme un tableau d'objet any[]
+        const annee = parseInt(this.convention.annee.split('/')[0]);
         const elementPedagogiques: any[] = [];
 
         if (this.convention.codeElp) {
-          // Ajoute l'élément pédagogique si présent dans la convention
           elementPedagogiques.push({
             codElp: this.convention.codeElp,
             libElp: this.convention.libelleELP,
@@ -273,8 +276,8 @@ export class EtudiantComponent implements OnInit, OnChanges {
           etapeInscription: {
             codeEtp: this.convention.etape.id.code,
             codVrsVet: this.convention.etape.id.codeVersionEtape,
-            libWebVet: this.convention.libWebVet,
-            codeComposante: this.convention.codeComposante,
+            libWebVet: this.convention.etape.libelle,
+            codeComposante: this.convention.ufr.id.code,
             libComposante: this.convention.ufr?.libelle || this.convention.libelleComposante
           },
           typeConvention: this.convention.typeConvention ? {id: this.convention.typeConvention.id, libelle: this.convention.typeConvention.libelle} : null,
@@ -284,7 +287,7 @@ export class EtudiantComponent implements OnInit, OnChanges {
         this.formConvention.get('inscription')?.setValue(inscription);
         if (inscription.typeConvention) {
           this.formConvention.get('idTypeConvention')?.setValue(inscription.typeConvention.id);
-          if( !this.canEditTypeConvention) {
+          if (!this.canEditTypeConvention) {
             this.formConvention.get('idTypeConvention')?.disable();
           }
         }
@@ -293,60 +296,120 @@ export class EtudiantComponent implements OnInit, OnChanges {
           this.formConvention.get('inscriptionElp')?.setValue(elementPedagogiques[0]);
         }
 
-        // S'assurer que l'inscription est disponible pour l'interface
         this.inscriptions = [inscription];
+      } else {
+        this.inscriptions = [];
       }
-    } else {
-      // Pour une nouvelle convention, obtenir les données depuis Apogee
-      this.etudiantService.getApogeeData(row.codEtu).subscribe((response: any) => {
-        this.etudiant = response;
-
-        // Remplir le formulaire avec les valeurs de l'étudiant
-        this.formConvention.get('adresseEtudiant')?.setValue(this.convention?.adresseEtudiant || this.etudiant.mainAddress);
-        this.formConvention.get('codePostalEtudiant')?.setValue(this.convention?.codePostalEtudiant || this.etudiant.postalCode);
-        this.formConvention.get('villeEtudiant')?.setValue(this.convention?.villeEtudiant || this.etudiant.town);
-        this.formConvention.get('paysEtudiant')?.setValue(this.convention?.paysEtudiant || this.etudiant.country);
-        this.formConvention.get('telEtudiant')?.setValue(this.convention?.telEtudiant || this.etudiant.phone);
-        this.formConvention.get('telPortableEtudiant')?.setValue(this.convention?.telPortableEtudiant || this.etudiant.portablePhone);
-        this.formConvention.get('courrielPersoEtudiant')?.setValue(this.convention?.courrielPersoEtudiant || this.etudiant.mailPerso);
-
-        this.activatedRoute.params.subscribe((param: any) => {
-          const pathId = param.id;
-          if (pathId === 'create') {
-            this.titleService.title = 'Création d\'une convention pour ' + this.etudiant.nompatro + ' ' + this.etudiant.prenom;
-          }
-        });
-      });
-
-      // Récupérer les inscriptions
-      this.etudiantService.getApogeeInscriptions(row.codEtu, this.convention ? this.convention.annee : null).subscribe((response: any) => {
-        this.inscriptions = response;
-        this.inscriptions.sort((a,b) => a.annee < b.annee ? 1 : -1);
-        if (this.inscriptions.length === 1) {
-          this.formConvention.get('inscription')?.setValue(this.inscriptions[0]);
-        }
-
-        if (this.convention?.etape) {
-          const inscription = this.inscriptions.find((i: any) => {
-            return i.etapeInscription.codeEtp === this.convention.etape.id.code;
-          });
-
-          if (inscription) {
-            this.formConvention.get('inscription')?.setValue(inscription);
-
-            if (this.convention.codeElp) {
-              const inscriptionElp = inscription.elementPedagogiques.find((i: any) => {
-                return i.codElp === this.convention.codeElp;
-              });
-
-              this.formConvention.get('inscriptionElp')?.setValue(inscriptionElp);
-            }
-          } else if (this.inscriptions.length > 1) {
-            this.formConvention.get('inscription')?.reset();
-          }
-        }
-      });
+      return;
     }
+
+    this.etudiantService.getApogeeData(row.codEtu).subscribe((response: any) => {
+      this.etudiant = response;
+
+      this.formConvention.get('adresseEtudiant')?.setValue(this.convention?.adresseEtudiant || this.etudiant.mainAddress);
+      this.formConvention.get('codePostalEtudiant')?.setValue(this.convention?.codePostalEtudiant || this.etudiant.postalCode);
+      this.formConvention.get('villeEtudiant')?.setValue(this.convention?.villeEtudiant || this.etudiant.town);
+      this.formConvention.get('paysEtudiant')?.setValue(this.convention?.paysEtudiant || this.etudiant.country);
+      this.formConvention.get('telEtudiant')?.setValue(this.convention?.telEtudiant || this.etudiant.phone);
+      this.formConvention.get('telPortableEtudiant')?.setValue(this.convention?.telPortableEtudiant || this.etudiant.portablePhone);
+      this.formConvention.get('courrielPersoEtudiant')?.setValue(this.convention?.courrielPersoEtudiant || this.etudiant.mailPerso);
+
+      this.activatedRoute.params.subscribe((param: any) => {
+        const pathId = param.id;
+        if (pathId === 'create') {
+          this.titleService.title = 'Création d\'une convention pour ' + this.etudiant.nompatro + ' ' + this.etudiant.prenom;
+        }
+      });
+    });
+
+    this.loadApogeeInscriptions(row.codEtu);
+  }
+
+  loadApogeeInscriptionsOnDemand(isOpened: boolean = true): void {
+    if (!isOpened || !this.convention?.id || !this.modifiable || !this.selectedNumEtudiant) {
+      return;
+    }
+
+    this.loadApogeeInscriptions(this.selectedNumEtudiant);
+  }
+
+  private loadApogeeInscriptions(numEtudiant: string): void {
+    if (!numEtudiant || this.isLoadingApogeeInscriptions || this.hasLoadedApogeeInscriptions) {
+      return;
+    }
+
+    this.isLoadingApogeeInscriptions = true;
+    this.apogeeInscriptionsLoadFailed = false;
+    this.etudiantService.getCachedApogeeInscriptions(numEtudiant, this.convention ? this.convention.annee : null).subscribe({
+      next: (response: any) => {
+        this.applyApogeeInscriptions(response || []);
+        this.hasLoadedApogeeInscriptions = true;
+      },
+      error: () => {
+        this.isLoadingApogeeInscriptions = false;
+        this.apogeeInscriptionsLoadFailed = true;
+        if (this.convention?.id) {
+          this.messageService.setWarning('Impossible de charger les formations Apogee. Les donnees enregistrees restent affichees.');
+        } else {
+          this.messageService.setError('Impossible de charger les formations Apogee.');
+        }
+      },
+      complete: () => {
+        this.isLoadingApogeeInscriptions = false;
+      }
+    });
+  }
+
+  private applyApogeeInscriptions(response: any[]): void {
+    const inscriptions = [...response];
+    inscriptions.sort((a, b) => a.annee < b.annee ? 1 : -1);
+    this.inscriptions = inscriptions;
+
+    const reference = this.getInscriptionReference();
+    const matchingInscription = this.inscriptions.find((inscription: any) => {
+      const sameCode = inscription.etapeInscription.codeEtp === reference.codeEtp;
+      const sameVersion = !reference.codVrsVet || !inscription.etapeInscription.codVrsVet || inscription.etapeInscription.codVrsVet === reference.codVrsVet;
+      return sameCode && sameVersion;
+    });
+
+    if (matchingInscription) {
+      this.formConvention.get('inscription')?.setValue(matchingInscription);
+      if (reference.codeElp) {
+        const inscriptionElp = matchingInscription.elementPedagogiques?.find((elp: any) => elp.codElp === reference.codeElp);
+        this.formConvention.get('inscriptionElp')?.setValue(inscriptionElp || null);
+      }
+      return;
+    }
+
+    if (this.inscriptions.length === 1) {
+      this.formConvention.get('inscription')?.setValue(this.inscriptions[0]);
+      return;
+    }
+
+    if (this.convention?.etape) {
+      this.formConvention.get('inscription')?.reset();
+      this.formConvention.get('inscriptionElp')?.reset();
+    }
+  }
+
+  private getInscriptionReference(): { codeEtp: string | null; codVrsVet: string | null; codeElp: string | null } {
+    const selectedInscription = this.formConvention.get('inscription')?.value;
+    const selectedElp = this.formConvention.get('inscriptionElp')?.value;
+
+    return {
+      codeEtp: selectedInscription?.etapeInscription?.codeEtp ?? this.convention?.etape?.id?.code ?? null,
+      codVrsVet: selectedInscription?.etapeInscription?.codVrsVet ?? this.convention?.etape?.id?.codeVersionEtape ?? null,
+      codeElp: selectedElp?.codElp ?? this.convention?.codeElp ?? null,
+    };
+  }
+
+  getInscriptionLibelle(inscription: any): string {
+    const etapeInscription = inscription?.etapeInscription;
+    return etapeInscription?.libWebVet || "";
+  }
+
+  getInscriptionCodeComposante(inscription: any): string | null {
+    return inscription?.etapeInscription?.codeComposante || null;
   }
 
   get selectedInscription() {
@@ -385,7 +448,7 @@ export class EtudiantComponent implements OnInit, OnChanges {
         data.codeComposante = this.formConvention.value.inscription.etapeInscription.codeComposante;
         data.libelleComposante = this.formConvention.value.inscription.etapeInscription.libComposante;
         data.codeEtape = this.formConvention.value.inscription.etapeInscription.codeEtp;
-        data.libelleEtape = this.formConvention.value.inscription.etapeInscription.libWebVet;
+        data.libelleEtape = this.getInscriptionLibelle(this.formConvention.value.inscription);
         data.codeVersionEtape = this.formConvention.value.inscription.etapeInscription.codVrsVet;
         data.annee = this.formConvention.value.inscription.annee;
       } else if (this.convention) {

--- a/src/frontend/src/app/services/etudiant.service.ts
+++ b/src/frontend/src/app/services/etudiant.service.ts
@@ -1,13 +1,16 @@
 import { Injectable } from '@angular/core';
-import { Observable } from "rxjs";
+import { Observable, throwError } from "rxjs";
 import { environment } from "../../environments/environment";
 import { HttpClient } from "@angular/common/http";
 import {PaginatedResponse, PaginatedService} from "./paginated.service";
+import { catchError, shareReplay } from "rxjs/operators";
 
 @Injectable({
   providedIn: 'root'
 })
 export class EtudiantService implements PaginatedService<Etudiant> {
+
+  private apogeeInscriptionsCache = new Map<string, Observable<any>>();
 
   constructor(private http: HttpClient) { }
 
@@ -26,6 +29,25 @@ export class EtudiantService implements PaginatedService<Etudiant> {
   getApogeeInscriptions(numEtudiant: string, annee: string): Observable<any> {
     const a = annee ? annee.split('/')[0] : '';
     return this.http.get(`${environment.apiUrl}/etudiants/${numEtudiant}/apogee-inscriptions`, {params: {annee: a ?? null} });
+  }
+
+  getCachedApogeeInscriptions(numEtudiant: string, annee: string): Observable<any> {
+    const cacheKey = `${numEtudiant}-${annee ? annee.split('/')[0] : ''}`;
+    const cachedRequest = this.apogeeInscriptionsCache.get(cacheKey);
+    if (cachedRequest) {
+      return cachedRequest;
+    }
+
+    const request$ = this.getApogeeInscriptions(numEtudiant, annee).pipe(
+      catchError((error) => {
+        this.apogeeInscriptionsCache.delete(cacheKey);
+        return throwError(() => error);
+      }),
+      shareReplay(1),
+    );
+
+    this.apogeeInscriptionsCache.set(cacheKey, request$);
+    return request$;
   }
 
   getByLogin(login: string): Observable<Etudiant> {


### PR DESCRIPTION
Dans la création / modification d’une convention, au niveau de l’étudiant :

- Correction de la régression empêchant la modification de la formation
- Chargement des inscriptions Apogée uniquement à l’ouverture du champ Formation
- Mise en cache des inscriptions Apogée pour éviter de multiplier les appels à Apogée