### PR TITLE
Limiter les données remontées concernant les contacts et les services

### DIFF
--- a/src/frontend/src/app/components/gestion-etab-accueil/gestion-etab-accueil.component.ts
+++ b/src/frontend/src/app/components/gestion-etab-accueil/gestion-etab-accueil.component.ts
@@ -209,7 +209,7 @@ export class GestionEtabAccueilComponent implements OnInit {
 
   refreshContacts(): void{
     if (this.service){
-      this.contactService.getByService(this.service.id, -1).subscribe((response: any) => {
+      this.contactService.getByServiceDetail(this.service.id, -1).subscribe((response: any) => {
         this.contacts = response.sort((a: any, b: any) => a.nom.localeCompare(b.nom));
       });
     }

--- a/src/frontend/src/app/services/contact.service.ts
+++ b/src/frontend/src/app/services/contact.service.ts
@@ -19,12 +19,12 @@ export class ContactService implements PaginatedService {
     return this.http.get(`${environment.apiUrl}/contacts/export/${format}`, {params: {headers, predicate, sortOrder, filters}, responseType: 'blob'});
   }
 
-  getById(id: number): Observable<any> {
-    return this.http.get(`${environment.apiUrl}/contacts/${id}`);
-  }
-
   getByService(id: number, idCentreGestion: any): Observable<any> {
     return this.http.get(`${environment.apiUrl}/contacts/getByService/${id}`, {params: {idCentreGestion}});
+  }
+
+  getByServiceDetail(id: number, idCentreGestion: any): Observable<any> {
+    return this.http.get(`${environment.apiUrl}/contacts/getByService/${id}/detail`, {params: {idCentreGestion}});
   }
 
   update(id: number, data: any): Observable<any> {

--- a/src/frontend/src/app/services/service.service.ts
+++ b/src/frontend/src/app/services/service.service.ts
@@ -19,10 +19,6 @@ export class ServiceService implements PaginatedService {
     return this.http.get(`${environment.apiUrl}/services/export/${format}`, {params: {headers, predicate, sortOrder, filters}, responseType: 'blob'});
   }
 
-  getById(id: number): Observable<any> {
-    return this.http.get(`${environment.apiUrl}/services/${id}`);
-  }
-
   getByStructure(id: number, idCentreGestion: any): Observable<any> {
     return this.http.get(`${environment.apiUrl}/services/getByStructure/${id}`, {params: {idCentreGestion}});
   }

--- a/src/main/java/org/esup_portail/esup_stage/controller/ContactController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/ContactController.java
@@ -36,16 +36,6 @@ public class ContactController {
     @Autowired
     CiviliteJpaRepository civiliteJpaRepository;
 
-    @GetMapping("/{id}")
-    @Secure(fonctions = {AppFonctionEnum.SERVICE_CONTACT_ACC}, droits = {DroitEnum.LECTURE})
-    public ContactDetailDto getById(@PathVariable("id") int id) {
-        Contact contact = contactJpaRepository.findById(id);
-        if (contact == null) {
-            throw new AppException(HttpStatus.NOT_FOUND, "Contact non trouvé");
-        }
-        return buildContactDetailDto(contact);
-    }
-
     @GetMapping("/getByService/{id}")
     @Secure(fonctions = {AppFonctionEnum.SERVICE_CONTACT_ACC}, droits = {DroitEnum.LECTURE})
     public List<ContactDto> getByService(@PathVariable("id") int id, @RequestParam(value = "idCentreGestion", required = false, defaultValue = "-1") Integer idCentreGestion) {
@@ -78,6 +68,40 @@ public class ContactController {
         }
 
         return contacts.stream().map(this::buildContactDto).toList();
+    }
+
+    @GetMapping("/getByService/{id}/detail")
+    @Secure(fonctions = {AppFonctionEnum.SERVICE_CONTACT_ACC}, droits ={ DroitEnum.MODIFICATION},forbiddenEtu = true)
+    public List<ContactDetailDto> getByServiceWithDetail(@PathVariable("id") int id, @RequestParam(value = "idCentreGestion", required = false, defaultValue = "-1") Integer idCentreGestion) {
+        List<Contact> contacts = contactJpaRepository.findByService(id);
+
+        if (contacts == null) {
+            throw new AppException(HttpStatus.NOT_FOUND, "Contact non trouvé");
+        }
+
+        Utilisateur utilisateur = ServiceContext.getUtilisateur();
+        /*
+         * Si idCentreGestion != -1, on est dans le cadre d'une convention
+         *
+         * Dans ce cas pour les utilisateurs gestionnaires, on ne renvoit que les contacts qui sont rattachés au centre de la convention ou
+           qui ont un centre de gestion avec code confidentialité égale à 0 ou au centre de gestion de type établissement
+         * */
+        if ((UtilisateurHelper.isRole(utilisateur, Role.GES) || UtilisateurHelper.isRole(utilisateur, Role.RESP_GES)) && idCentreGestion != -1) {
+            CentreGestion centreGestion = centreGestionJpaRepository.findById(idCentreGestion.intValue());
+            if (centreGestion == null) {
+                throw new AppException(HttpStatus.NOT_FOUND, "CentreGestion non trouvé");
+            }
+            List<ContactDetailDto> filteredContacts = new ArrayList<>();
+            for (Contact contact : contacts) {
+                if (contact.getCentreGestion().getCodeConfidentialite().getCode().equals("0") || contact.getCentreGestion().getId() == centreGestion.getId() ||
+                        contact.getCentreGestion().getNiveauCentre().getLibelle().equals("ETABLISSEMENT")) {
+                    filteredContacts.add(buildContactDetailDto(contact));
+                }
+            }
+            return filteredContacts;
+        }
+
+        return contacts.stream().map(this::buildContactDetailDto).toList();
     }
 
     @PostMapping

--- a/src/main/java/org/esup_portail/esup_stage/controller/ContactController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/ContactController.java
@@ -184,6 +184,7 @@ public class ContactController {
 
     private ContactDetailDto buildContactDetailDto(Contact contact) {
         ContactDetailDto contactDetailDto = new ContactDetailDto();
+        contactDetailDto.setId(contact.getId());
         contactDetailDto.setNom(contact.getNom());
         contactDetailDto.setPrenom(contact.getPrenom());
         contactDetailDto.setMail(contact.getMail());

--- a/src/main/java/org/esup_portail/esup_stage/controller/ContactController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/ContactController.java
@@ -1,11 +1,9 @@
 package org.esup_portail.esup_stage.controller;
 
-import com.fasterxml.jackson.annotation.JsonView;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import org.esup_portail.esup_stage.dto.ContactDetailDto;
+import org.esup_portail.esup_stage.dto.ContactDto;
 import org.esup_portail.esup_stage.dto.ContactFormDto;
-import org.esup_portail.esup_stage.dto.PaginatedResponse;
-import org.esup_portail.esup_stage.dto.view.Views;
 import org.esup_portail.esup_stage.enums.AppFonctionEnum;
 import org.esup_portail.esup_stage.enums.DroitEnum;
 import org.esup_portail.esup_stage.exception.AppException;
@@ -27,9 +25,6 @@ import java.util.List;
 public class ContactController {
 
     @Autowired
-    ContactRepository contactRepository;
-
-    @Autowired
     ContactJpaRepository contactJpaRepository;
 
     @Autowired
@@ -41,30 +36,19 @@ public class ContactController {
     @Autowired
     CiviliteJpaRepository civiliteJpaRepository;
 
-    // Cette route n'est jamais utilisée
-    // @JsonView(Views.List.class)
-    // @GetMapping
-    // @Secure(fonctions = {AppFonctionEnum.SERVICE_CONTACT_ACC}, droits = {DroitEnum.LECTURE})
-    // public PaginatedResponse<Contact> search(@RequestParam(name = "page", defaultValue = "1") int page, @RequestParam(name = "perPage", defaultValue = "50") int perPage, @RequestParam("predicate") String predicate, @RequestParam(name = "sortOrder", defaultValue = "asc") String sortOrder, @RequestParam(name = "filters", defaultValue = "{}") String filters, HttpServletResponse response) {
-    //     PaginatedResponse<Contact> paginatedResponse = new PaginatedResponse<>();
-    //     paginatedResponse.setTotal(contactRepository.count(filters));
-    //     paginatedResponse.setData(contactRepository.findPaginated(page, perPage, predicate, sortOrder, filters));
-    //     return paginatedResponse;
-    // }
-
     @GetMapping("/{id}")
     @Secure(fonctions = {AppFonctionEnum.SERVICE_CONTACT_ACC}, droits = {DroitEnum.LECTURE})
-    public Contact getById(@PathVariable("id") int id) {
+    public ContactDetailDto getById(@PathVariable("id") int id) {
         Contact contact = contactJpaRepository.findById(id);
         if (contact == null) {
             throw new AppException(HttpStatus.NOT_FOUND, "Contact non trouvé");
         }
-        return contact;
+        return buildContactDetailDto(contact);
     }
 
     @GetMapping("/getByService/{id}")
     @Secure(fonctions = {AppFonctionEnum.SERVICE_CONTACT_ACC}, droits = {DroitEnum.LECTURE})
-    public List<Contact> getByService(@PathVariable("id") int id, @RequestParam(value = "idCentreGestion", required = false, defaultValue = "-1") Integer idCentreGestion) {
+    public List<ContactDto> getByService(@PathVariable("id") int id, @RequestParam(value = "idCentreGestion", required = false, defaultValue = "-1") Integer idCentreGestion) {
         List<Contact> contacts = contactJpaRepository.findByService(id);
 
         if (contacts == null) {
@@ -83,17 +67,17 @@ public class ContactController {
             if (centreGestion == null) {
                 throw new AppException(HttpStatus.NOT_FOUND, "CentreGestion non trouvé");
             }
-            List<Contact> filteredContacts = new ArrayList<Contact>();
+            List<ContactDto> filteredContacts = new ArrayList<>();
             for (Contact contact : contacts) {
                 if (contact.getCentreGestion().getCodeConfidentialite().getCode().equals("0") || contact.getCentreGestion().getId() == centreGestion.getId() ||
                         contact.getCentreGestion().getNiveauCentre().getLibelle().equals("ETABLISSEMENT")) {
-                    filteredContacts.add(contact);
+                    filteredContacts.add(buildContactDto(contact));
                 }
             }
             return filteredContacts;
         }
 
-        return contacts;
+        return contacts.stream().map(this::buildContactDto).toList();
     }
 
     @PostMapping
@@ -163,5 +147,27 @@ public class ContactController {
         contact.setTel(contactFormDto.getTel());
         contact.setFax(contactFormDto.getFax());
         contact.setMail(contactFormDto.getMail());
+    }
+
+    private ContactDto buildContactDto(Contact contact) {
+        ContactDto contactDto = new ContactDto();
+        contactDto.setId(contact.getId());
+        contactDto.setNom(contact.getNom());
+        contactDto.setPrenom(contact.getPrenom());
+        contactDto.setIdCentreGestion(contact.getCentreGestion().getId());
+        return contactDto;
+    }
+
+    private ContactDetailDto buildContactDetailDto(Contact contact) {
+        ContactDetailDto contactDetailDto = new ContactDetailDto();
+        contactDetailDto.setNom(contact.getNom());
+        contactDetailDto.setPrenom(contact.getPrenom());
+        contactDetailDto.setMail(contact.getMail());
+        contactDetailDto.setTel(contact.getTel());
+        contactDetailDto.setFonction(contact.getFonction());
+        contactDetailDto.setFax(contact.getFax());
+        contactDetailDto.setCivilite(contact.getCivilite());
+        contactDetailDto.setIdCentreGestion(contact.getCentreGestion().getId());
+        return contactDetailDto;
     }
 }

--- a/src/main/java/org/esup_portail/esup_stage/controller/ServiceController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/ServiceController.java
@@ -3,6 +3,7 @@ package org.esup_portail.esup_stage.controller;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.esup_portail.esup_stage.dto.PaginatedResponse;
+import org.esup_portail.esup_stage.dto.ServiceDto;
 import org.esup_portail.esup_stage.dto.ServiceFormDto;
 import org.esup_portail.esup_stage.enums.AppFonctionEnum;
 import org.esup_portail.esup_stage.enums.DroitEnum;
@@ -45,26 +46,16 @@ public class ServiceController {
 
     @GetMapping
     @Secure(fonctions = {AppFonctionEnum.SERVICE_CONTACT_ACC}, droits = {DroitEnum.LECTURE})
-    public PaginatedResponse<Service> search(@RequestParam(name = "page", defaultValue = "1") int page, @RequestParam(name = "perPage", defaultValue = "50") int perPage, @RequestParam("predicate") String predicate, @RequestParam(name = "sortOrder", defaultValue = "asc") String sortOrder, @RequestParam(name = "filters", defaultValue = "{}") String filters, HttpServletResponse response) {
-        PaginatedResponse<Service> paginatedResponse = new PaginatedResponse<>();
+    public PaginatedResponse<ServiceDto> search(@RequestParam(name = "page", defaultValue = "1") int page, @RequestParam(name = "perPage", defaultValue = "50") int perPage, @RequestParam("predicate") String predicate, @RequestParam(name = "sortOrder", defaultValue = "asc") String sortOrder, @RequestParam(name = "filters", defaultValue = "{}") String filters, HttpServletResponse response) {
+        PaginatedResponse<ServiceDto> paginatedResponse = new PaginatedResponse<>();
         paginatedResponse.setTotal(serviceRepository.count(filters));
-        paginatedResponse.setData(serviceRepository.findPaginated(page, perPage, predicate, sortOrder, filters));
+        paginatedResponse.setData(serviceRepository.findPaginated(page, perPage, predicate, sortOrder, filters).stream().map(this::buildServiceDto).toList());
         return paginatedResponse;
-    }
-
-    @GetMapping("/{id}")
-    @Secure(fonctions = {AppFonctionEnum.SERVICE_CONTACT_ACC}, droits = {DroitEnum.LECTURE})
-    public Service getById(@PathVariable("id") int id) {
-        Service service = serviceJpaRepository.findById(id);
-        if (service == null) {
-            throw new AppException(HttpStatus.NOT_FOUND, "Service non trouvée");
-        }
-        return service;
     }
 
     @GetMapping("/getByStructure/{id}")
     @Secure(fonctions = {AppFonctionEnum.SERVICE_CONTACT_ACC}, droits = {DroitEnum.LECTURE})
-    public List<Service> getByStructure(@PathVariable("id") int id, @RequestParam(value = "idCentreGestion", required = false, defaultValue = "-1") Integer idCentreGestion) {
+    public List<ServiceDto> getByStructure(@PathVariable("id") int id, @RequestParam(value = "idCentreGestion", required = false, defaultValue = "-1") Integer idCentreGestion) {
         List<Service> services = serviceJpaRepository.findByStructure(id);
         if (services == null) {
             throw new AppException(HttpStatus.NOT_FOUND, "Service non trouvée");
@@ -82,18 +73,18 @@ public class ServiceController {
             if (centreGestion == null) {
                 throw new AppException(HttpStatus.NOT_FOUND, "CentreGestion non trouvé");
             }
-            List<Service> filteredservices = new ArrayList<Service>();
+            List<ServiceDto> filteredservices = new ArrayList<>();
             for (Service service : services) {
                 if (service.getCentreGestion().getCodeConfidentialite().getCode().equals("0") || service.getCentreGestion().getId() == centreGestion.getId() ||
                         service.getCentreGestion().getNiveauCentre().getLibelle().equals("ETABLISSEMENT")) {
-                    filteredservices.add(service);
+                    filteredservices.add(buildServiceDto(service));
                 }
             }
             return filteredservices;
         }
 
 
-        return services;
+        return services.stream().map(this::buildServiceDto).toList();
     }
 
     @PostMapping
@@ -169,6 +160,20 @@ public class ServiceController {
         service.setPays(pays);
         service.setTelephone(serviceFormDto.getTelephone());
 
+    }
+
+    private ServiceDto buildServiceDto(Service service) {
+        ServiceDto serviceDto = new ServiceDto();
+        serviceDto.setId(service.getId());
+        serviceDto.setNom(service.getNom());
+        serviceDto.setVoie(service.getVoie());
+        serviceDto.setCodePostal(service.getCodePostal());
+        serviceDto.setBatimentResidence(service.getBatimentResidence());
+        serviceDto.setCommune(service.getCommune());
+        serviceDto.setTelephone(service.getTelephone());
+        serviceDto.setPays(service.getPays());
+        serviceDto.setIdCentreGestion(service.getCentreGestion().getId());
+        return serviceDto;
     }
 
 }

--- a/src/main/java/org/esup_portail/esup_stage/dto/ContactDetailDto.java
+++ b/src/main/java/org/esup_portail/esup_stage/dto/ContactDetailDto.java
@@ -1,0 +1,16 @@
+package org.esup_portail.esup_stage.dto;
+
+import lombok.Data;
+import org.esup_portail.esup_stage.model.Civilite;
+
+@Data
+public class ContactDetailDto {
+    private String nom;
+    private String prenom;
+    private String mail;
+    private String tel;
+    private String fonction;
+    private Civilite civilite;
+    private String fax;
+    private int idCentreGestion;
+}

--- a/src/main/java/org/esup_portail/esup_stage/dto/ContactDetailDto.java
+++ b/src/main/java/org/esup_portail/esup_stage/dto/ContactDetailDto.java
@@ -5,6 +5,7 @@ import org.esup_portail.esup_stage.model.Civilite;
 
 @Data
 public class ContactDetailDto {
+    private int id;
     private String nom;
     private String prenom;
     private String mail;

--- a/src/main/java/org/esup_portail/esup_stage/dto/ContactDto.java
+++ b/src/main/java/org/esup_portail/esup_stage/dto/ContactDto.java
@@ -1,0 +1,11 @@
+package org.esup_portail.esup_stage.dto;
+
+import lombok.Data;
+
+@Data
+public class ContactDto {
+    private int id;
+    private String nom;
+    private String prenom;
+    private int idCentreGestion;
+}

--- a/src/main/java/org/esup_portail/esup_stage/dto/ServiceDto.java
+++ b/src/main/java/org/esup_portail/esup_stage/dto/ServiceDto.java
@@ -1,0 +1,17 @@
+package org.esup_portail.esup_stage.dto;
+
+import lombok.Data;
+import org.esup_portail.esup_stage.model.Pays;
+
+@Data
+public class ServiceDto {
+    private int id;
+    private String nom;
+    private String voie;
+    private String codePostal;
+    private String batimentResidence;
+    private String commune;
+    private String telephone;
+    private Pays pays;
+    private int idCentreGestion;
+}


### PR DESCRIPTION
- Limitation des données remontées pour les contacts via ContactDto et ContactDetailDto.
- Limitation des données remontées pour les services via ServiceDto.
- Ajout d’un endpoint de détail des contacts rattachés à un service.
- Adaptation du front pour utiliser l’endpoint détail lorsque nécessaire.
- Suppression des appels front aux endpoints getById contacts/services devenus inutiles.