### PR TITLE
Bugfix/limiter donnees evals

### DIFF
--- a/src/main/java/org/esup_portail/esup_stage/controller/FicheEvaluationController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/FicheEvaluationController.java
@@ -6,19 +6,24 @@ import org.esup_portail.esup_stage.dto.*;
 import org.esup_portail.esup_stage.enums.AppFonctionEnum;
 import org.esup_portail.esup_stage.enums.DroitEnum;
 import org.esup_portail.esup_stage.exception.AppException;
-import org.esup_portail.esup_stage.model.CentreGestion;
-import org.esup_portail.esup_stage.model.FicheEvaluation;
-import org.esup_portail.esup_stage.model.QuestionSupplementaire;
+import org.esup_portail.esup_stage.model.*;
+import org.esup_portail.esup_stage.model.helper.UtilisateurHelper;
 import org.esup_portail.esup_stage.repository.CentreGestionJpaRepository;
+import org.esup_portail.esup_stage.repository.ConventionJpaRepository;
 import org.esup_portail.esup_stage.repository.FicheEvaluationJpaRepository;
 import org.esup_portail.esup_stage.repository.FicheEvaluationRepository;
+import org.esup_portail.esup_stage.repository.PersonnelCentreGestionJpaRepository;
 import org.esup_portail.esup_stage.repository.QuestionSupplementaireJpaRepository;
+import org.esup_portail.esup_stage.security.ServiceContext;
 import org.esup_portail.esup_stage.security.interceptor.Secure;
+import org.esup_portail.esup_stage.service.EtudiantSecurityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 @ApiController
 @RequestMapping("/ficheEvaluation")
@@ -35,6 +40,15 @@ public class FicheEvaluationController {
 
     @Autowired
     CentreGestionJpaRepository centreGestionJpaRepository;
+
+    @Autowired
+    ConventionJpaRepository conventionJpaRepository;
+
+    @Autowired
+    EtudiantSecurityService etudiantSecurityService;
+
+    @Autowired
+    PersonnelCentreGestionJpaRepository personnelCentreGestionJpaRepository;
 
     @GetMapping
     @Secure(fonctions = {AppFonctionEnum.PARAM_CENTRE}, droits = {DroitEnum.LECTURE})
@@ -58,10 +72,12 @@ public class FicheEvaluationController {
     @GetMapping("/getByCentreGestion/{id}")
     @Secure(fonctions = {AppFonctionEnum.CONVENTION,AppFonctionEnum.PARAM_CENTRE}, droits = {DroitEnum.LECTURE})
     public FicheEvaluation getByCentreGestion(@PathVariable("id") int id) {
+        CentreGestion centreGestion = centreGestionJpaRepository.findById(id);
+        checkCanViewCentreGestion(centreGestion);
+
         FicheEvaluation ficheEvaluation = ficheEvaluationJpaRepository.findByCentreGestion(id);
         if (ficheEvaluation == null) {
             ficheEvaluation = new FicheEvaluation();
-            CentreGestion centreGestion = centreGestionJpaRepository.findById(id);
             if (centreGestion == null) {
                 throw new AppException(HttpStatus.NOT_FOUND, "CentreGestion non trouvé");
             }
@@ -69,6 +85,46 @@ public class FicheEvaluationController {
             return ficheEvaluationJpaRepository.saveAndFlush(ficheEvaluation);
         }
         return ficheEvaluation;
+    }
+
+    private void checkCanViewCentreGestion(CentreGestion centreGestion) {
+        Utilisateur utilisateur = ServiceContext.getUtilisateur();
+        if (utilisateur == null) {
+            throw new AppException(HttpStatus.UNAUTHORIZED, "Vous n'etes pas autorise");
+        }
+        if (centreGestion == null) {
+            throw new AppException(HttpStatus.NOT_FOUND, "CentreGestion non trouve");
+        }
+        if (UtilisateurHelper.isRole(utilisateur, Role.ADM)) {
+            return;
+        }
+
+        List<String> identifiants = getUserIdentifiers(utilisateur);
+        boolean canView = false;
+        if (UtilisateurHelper.isRole(utilisateur, Role.GES) || UtilisateurHelper.isRole(utilisateur, Role.RESP_GES)) {
+            canView = !identifiants.isEmpty()
+                    && personnelCentreGestionJpaRepository.countByCentreGestionAndUidPersonnel(centreGestion.getId(), identifiants) > 0;
+        }
+        if (!canView && UtilisateurHelper.isRole(utilisateur, Role.ETU)) {
+            canView = etudiantSecurityService.isEtudiantInCentreGestion(utilisateur, centreGestion.getId());
+        }
+        if (!canView && UtilisateurHelper.isRole(utilisateur, Role.ENS)) {
+            canView = !identifiants.isEmpty()
+                    && conventionJpaRepository.countConventionByEnseignantAndCentreGestion(identifiants, centreGestion.getId()) > 0;
+        }
+
+        if (!canView) {
+            throw new AppException(HttpStatus.NOT_FOUND, "CentreGestion non trouve");
+        }
+    }
+
+    private List<String> getUserIdentifiers(Utilisateur utilisateur) {
+        return Stream.of(utilisateur.getUid(), utilisateur.getLogin())
+                .filter(Objects::nonNull)
+                .filter(value -> !value.isBlank())
+                .map(String::toLowerCase)
+                .distinct()
+                .toList();
     }
 
     @PutMapping("/saveAndValidateFicheEtudiant/{id}")

--- a/src/main/java/org/esup_portail/esup_stage/controller/ReponseEvaluationController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/ReponseEvaluationController.java
@@ -16,6 +16,7 @@ import org.esup_portail.esup_stage.repository.ReponseSupplementaireJpaRepository
 import org.esup_portail.esup_stage.security.ServiceContext;
 import org.esup_portail.esup_stage.security.interceptor.Secure;
 import org.esup_portail.esup_stage.service.AppConfigService;
+import org.esup_portail.esup_stage.service.ConventionService;
 import org.esup_portail.esup_stage.service.MailerService;
 import org.esup_portail.esup_stage.service.impression.ImpressionService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,10 +55,18 @@ public class ReponseEvaluationController {
     @Autowired
     AppConfigService appConfigService;
 
+    @Autowired
+    ConventionService conventionService;
+
     @GetMapping("/getByConvention/{id}")
     @Secure(fonctions = {AppFonctionEnum.CONVENTION}, droits = {DroitEnum.LECTURE})
     public ReponseEvaluation getByConvention(@PathVariable("id") int id) {
-        return reponseEvaluationJpaRepository.findByConvention(id);
+        Convention convention = conventionJpaRepository.findById(id);
+        if (convention == null) {
+            throw new AppException(HttpStatus.NOT_FOUND, "Convention non trouvée");
+        }
+        conventionService.canViewEditConvention(convention, ServiceContext.getUtilisateur());
+        return convention.getReponseEvaluation();
     }
 
     @PostMapping("/{id}/etudiant/valid/{valid}")

--- a/src/main/java/org/esup_portail/esup_stage/repository/ConventionJpaRepository.java
+++ b/src/main/java/org/esup_portail/esup_stage/repository/ConventionJpaRepository.java
@@ -69,6 +69,9 @@ public interface ConventionJpaRepository extends JpaRepository<Convention, Integ
     @Query("SELECT COUNT(c.id) FROM Convention c WHERE c.centreGestion.id = :idCentreGestion")
     Long countConventionWithCentreGestion(@Param("idCentreGestion") int idCentreGestion);
 
+    @Query("SELECT COUNT(c.id) FROM Convention c WHERE c.centreGestion.id = :idCentreGestion AND LOWER(c.enseignant.uidEnseignant) IN :identifiants")
+    Long countConventionByEnseignantAndCentreGestion(@Param("identifiants") Collection<String> identifiants, @Param("idCentreGestion") int idCentreGestion);
+
     @Query("SELECT COUNT(c.id) FROM Convention c WHERE c.structure.effectif.id = :idEffectif")
     Long countConventionWithEffectif(@Param("idEffectif") int idEffectif);
 

--- a/src/main/java/org/esup_portail/esup_stage/repository/PersonnelCentreGestionJpaRepository.java
+++ b/src/main/java/org/esup_portail/esup_stage/repository/PersonnelCentreGestionJpaRepository.java
@@ -18,6 +18,9 @@ public interface PersonnelCentreGestionJpaRepository extends JpaRepository<Perso
     @Query("SELECT COUNT(p) FROM PersonnelCentreGestion p WHERE p.uidPersonnel = :uid")
     long countPersonnelByLogin(@Param("uid") String uid);
 
+    @Query("SELECT COUNT(p.id) FROM PersonnelCentreGestion p WHERE p.centreGestion.id = :idCentreGestion AND LOWER(p.uidPersonnel) IN :identifiants")
+    long countByCentreGestionAndUidPersonnel(@Param("idCentreGestion") int idCentreGestion, @Param("identifiants") Collection<String> identifiants);
+
     @Transactional
     @Modifying
     @Query("DELETE FROM PersonnelCentreGestion p WHERE p.centreGestion.id = :id")

--- a/src/main/java/org/esup_portail/esup_stage/service/EtudiantSecurityService.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/EtudiantSecurityService.java
@@ -78,6 +78,22 @@ public class EtudiantSecurityService {
                 .collect(Collectors.toList());
     }
 
+    public boolean isEtudiantInCentreGestion(Utilisateur utilisateur, int idCentreGestion) {
+        if (utilisateur == null || utilisateur.getNumEtudiant() == null) {
+            return false;
+        }
+
+        List<ConventionFormationDto> inscriptions = apogeeService.getInscriptions(utilisateur, utilisateur.getNumEtudiant(), null);
+        if (inscriptions == null || inscriptions.isEmpty()) {
+            return false;
+        }
+
+        return inscriptions.stream()
+                .map(ConventionFormationDto::getCentreGestion)
+                .filter(Objects::nonNull)
+                .anyMatch(centreGestion -> centreGestion.getId() == idCentreGestion);
+    }
+
     public List<CritereGestion> getCriteresCentresGestionUtilisateur(List<Integer> idsCentresGestionUtilisateur) {
         if (idsCentresGestionUtilisateur == null || idsCentresGestionUtilisateur.isEmpty()) {
             return List.of();


### PR DESCRIPTION
- Ajout d’un contrôle d’accès sur GET /ficheEvaluation/getByCentreGestion/{id} pour vérifier que l'utilisateur est bien autorisé à consulter le centre de gestion demandé avant de récupérer ou créer la fiche d’évaluation associée
- Ajout d’un contrôle d’accès sur GET /api/reponseEvaluation/getByConvention/{id} pour vérifier que l'utilisateur est bien autorisé à consulter la convention demandé.
