### PR TITLE
issue #246 - conventions en masse: affichage du code UFR et libelle au survol

### DIFF
--- a/src/frontend/src/app/components/convention-create-en-masse/cadre-stage/cadre-stage.component.html
+++ b/src/frontend/src/app/components/convention-create-en-masse/cadre-stage/cadre-stage.component.html
@@ -55,7 +55,7 @@
 
         <ng-container matColumnDef="ufr.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">UFR</th>
-          <td mat-cell *matCellDef="let row">{{row.convention.ufr ? row.convention.ufr.libelle : ''}}</td>
+          <td mat-cell *matCellDef="let row" matTooltip="{{row.convention.ufr?.libelle??''}}">{{row.convention.ufr?.id?.code??''}}</td>
         </ng-container>
         <ng-container matColumnDef="etape.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">Étape d'étude</th>

--- a/src/frontend/src/app/components/convention-create-en-masse/enseignant-groupe/enseignant-groupe.component.html
+++ b/src/frontend/src/app/components/convention-create-en-masse/enseignant-groupe/enseignant-groupe.component.html
@@ -54,7 +54,7 @@
 
         <ng-container matColumnDef="ufr.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">UFR</th>
-          <td mat-cell *matCellDef="let row">{{row.convention.ufr ? row.convention.ufr.libelle : ''}}</td>
+          <td mat-cell *matCellDef="let row" matTooltip="{{row.convention.ufr?.libelle??''}}">{{row.convention.ufr?.id?.code??''}}</td>
         </ng-container>
         <ng-container matColumnDef="etape.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">Étape d'étude</th>

--- a/src/frontend/src/app/components/convention-create-en-masse/etab-accueil-groupe/etab-accueil-groupe.component.html
+++ b/src/frontend/src/app/components/convention-create-en-masse/etab-accueil-groupe/etab-accueil-groupe.component.html
@@ -56,7 +56,7 @@
 
         <ng-container matColumnDef="ufr.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">UFR</th>
-          <td mat-cell *matCellDef="let row">{{row.convention.ufr ? row.convention.ufr.libelle : ''}}</td>
+          <td mat-cell *matCellDef="let row" matTooltip="{{row.convention.ufr?.libelle??''}}">{{row.convention.ufr?.id?.code??''}}</td>
         </ng-container>
         <ng-container matColumnDef="etape.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">Étape d'étude</th>

--- a/src/frontend/src/app/components/convention-create-en-masse/gestion-groupe/gestion-groupe.component.html
+++ b/src/frontend/src/app/components/convention-create-en-masse/gestion-groupe/gestion-groupe.component.html
@@ -118,7 +118,7 @@
           </ng-container>
           <ng-container matColumnDef="ufr.libelle">
             <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">UFR</th>
-            <td mat-cell *matCellDef="let row">{{row.mergedConvention.ufr ? row.mergedConvention.ufr.libelle : ''}}</td>
+            <td mat-cell *matCellDef="let row" matTooltip="{{row.mergedConvention.ufr?.libelle??''}}">{{row.mergedConvention.ufr?.id?.code??''}}</td>
           </ng-container>
           <ng-container matColumnDef="etape.libelle">
             <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">Étape d'étude</th>
@@ -243,7 +243,7 @@
           </ng-container>
           <ng-container matColumnDef="ufr.libelle">
             <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">UFR</th>
-            <td mat-cell *matCellDef="let row">{{row.mergedConvention.ufr ? row.mergedConvention.ufr.libelle : ''}}</td>
+            <td mat-cell *matCellDef="let row" matTooltip="{{row.mergedConvention.ufr?.libelle??''}}">{{row.mergedConvention.ufr?.id?.code??''}}</td>
           </ng-container>
           <ng-container matColumnDef="etape.libelle">
             <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">Étape d'étude</th>

--- a/src/frontend/src/app/components/convention-create-en-masse/infos-stage/infos-stage.component.html
+++ b/src/frontend/src/app/components/convention-create-en-masse/infos-stage/infos-stage.component.html
@@ -54,7 +54,7 @@
 
         <ng-container matColumnDef="ufr.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">UFR</th>
-          <td mat-cell *matCellDef="let row">{{row.convention.ufr ? row.convention.ufr.libelle : ''}}</td>
+          <td mat-cell *matCellDef="let row" matTooltip="{{row.convention.ufr?.libelle??''}}">{{row.convention.ufr?.id?.code??''}}</td>
         </ng-container>
         <ng-container matColumnDef="etape.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">Étape d'étude</th>

--- a/src/frontend/src/app/components/convention-create-en-masse/selection-groupe-etu/selection-groupe-etu.component.html
+++ b/src/frontend/src/app/components/convention-create-en-masse/selection-groupe-etu/selection-groupe-etu.component.html
@@ -67,7 +67,7 @@
 
         <ng-container matColumnDef="ufr.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">UFR</th>
-          <td mat-cell *matCellDef="let row">{{row.convention.ufr ? row.convention.ufr.libelle : ''}}</td>
+          <td mat-cell *matCellDef="let row" matTooltip="{{row.convention.ufr?.libelle??''}}">{{row.convention.ufr?.id?.code??''}}</td>
         </ng-container>
         <ng-container matColumnDef="etape.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">Étape d'étude</th>

--- a/src/frontend/src/app/components/convention-create-en-masse/service-accueil-groupe/service-accueil-groupe.component.html
+++ b/src/frontend/src/app/components/convention-create-en-masse/service-accueil-groupe/service-accueil-groupe.component.html
@@ -53,7 +53,7 @@
 
         <ng-container matColumnDef="ufr.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">UFR</th>
-          <td mat-cell *matCellDef="let row">{{row.convention.ufr ? row.convention.ufr.libelle : ''}}</td>
+          <td mat-cell *matCellDef="let row" matTooltip="{{row.convention.ufr?.libelle??''}}">{{row.convention.ufr?.id?.code??''}}</td>
         </ng-container>
         <ng-container matColumnDef="etape.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">Étape d'étude</th>

--- a/src/frontend/src/app/components/convention-create-en-masse/signataire-groupe/signataire-groupe.component.html
+++ b/src/frontend/src/app/components/convention-create-en-masse/signataire-groupe/signataire-groupe.component.html
@@ -53,7 +53,7 @@
 
         <ng-container matColumnDef="ufr.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">UFR</th>
-          <td mat-cell *matCellDef="let row">{{row.convention.ufr ? row.convention.ufr.libelle : ''}}</td>
+          <td mat-cell *matCellDef="let row" matTooltip="{{row.convention.ufr?.libelle??''}}">{{row.convention.ufr?.id?.code??''}}</td>
         </ng-container>
         <ng-container matColumnDef="etape.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">Étape d'étude</th>

--- a/src/frontend/src/app/components/convention-create-en-masse/tuteur-accueil-groupe/tuteur-accueil-groupe.component.html
+++ b/src/frontend/src/app/components/convention-create-en-masse/tuteur-accueil-groupe/tuteur-accueil-groupe.component.html
@@ -53,7 +53,7 @@
 
         <ng-container matColumnDef="ufr.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">UFR</th>
-          <td mat-cell *matCellDef="let row">{{row.convention.ufr ? row.convention.ufr.libelle : ''}}</td>
+          <td mat-cell *matCellDef="let row" matTooltip="{{row.convention.ufr?.libelle??''}}">{{row.convention.ufr?.id?.code??''}}</td>
         </ng-container>
         <ng-container matColumnDef="etape.libelle">
           <th mat-header-cell *matHeaderCellDef mat-sort-header disableClear="true">Étape d'étude</th>


### PR DESCRIPTION
## Description / Objectif / Motivation / Contexte
<!-- Pourquoi ce changement est-il important ?
    Quel problème résout-il ?
    Veuillez inclure un résumé des modifications et du problème associé.
    Veuillez également inclure la motivation et le contexte pertinent.
    Énumérez toutes les dépendances requises par ce changement.
-->
Dans la gestion des conventions en masse, la colonne UFR prend beaucoup de place.

Cette PR propose d'utiliser le code d'UFR avec le libellé au survol de la souris.  

<!--- Si vous suggérez une nouvelle fonctionnalité ou un changement,
      merci d'ouvrir un ticket (issue) avant -->
Ticket: Fixes #246

## Cas d'acceptance (Comment cela a-t-il été testé ?)
<!-- ou lien https://... vers ticket avec les cas de test
Si vous corrigez un⋅e bogue, il devrait y avoir un ticket
le décrivant avec des étapes pour le reproduire -->

<!--
Veuillez décrire les tests que vous avez effectués pour vérifier vos modifications.
Fournir des instructions pour que nous puissions reproduire.
Veuillez également énumérer tous les détails pertinents de votre configuration de test.
-->

1. - Étant donné une composante _COMP_ de libellé _Composante_ et une étape _ETAPE_ avec des étudiants
   - Quand je suis sur la page _Créer des conventions en masse_
   - Quand je choisis la composante sous “Ajouter des étudiants au groupe”
   - Alors le code _COMP_ apparait dans la colonne UFR (sur tous les onglets)
   - Quand je passe la souris au dessus du code _COMP_ dans la colone UFR 
   - Alors le libelle _Composante_ apparait au dessus

<!-- Mentionnez s'il y a des tests automatisés pour ce changement 🙏 -->
<!-- Joindre des captures d'écran (le cas échéant) -->
### Tests automatisés
* aucun

## Type

<!--Veuillez supprimer des options qui ne sont pas pertinentes.-->
- ~☐ Correction de bogue (modification non cassante qui résout un problème).~
- 🗹 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
- ~☐ Changement cassant (correction qui entraînerait la/une fonctionnalité existante à ne pas fonctionner comme précédemment).~
- ~☐ Changement nécessitant une mise à jour de la documentation utilisateur.~

## Definition du fini

- [ ] Les cas d'acceptance ci-dessus ont été vérifiés.
- [ ] Revue par au moins un⋅e relecteur⋅ice autorisé⋅e.
- ~☐ Documentation(s) mise(s) à jour (utilisateur, technique, commentaires de code compris).~
- ~☐ Si des changements _cassants_ sont introduits, ils sont dûment décrits
  et les étapes de montée de version décrites (éventuellement scriptés).~