### PR TITLE
issue #598 - conventions en masse: filtres service et structure avec/sans saisie pour tout le groupe

### DIFF
--- a/src/frontend/src/app/components/convention-create-en-masse/service-accueil-groupe/service-accueil-groupe.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/service-accueil-groupe/service-accueil-groupe.component.ts
@@ -49,7 +49,7 @@ export class ServiceAccueilGroupeComponent implements OnInit, OnChanges {
     this.columns.push('etab');
     this.columns.push('service')
     this.filters = [...this.sharedData.filters];
-    this.filters.push({ id: 'convention.structure.id', libelle: 'Structure d\'accueil', type: 'list', options: [], keyLibelle: 'raisonSociale', keyId: 'id'});
+    this.filters.push({ id: 'convention.structure.id', libelle: 'Structure d\'accueil', type: 'list', options: [], keyLibelle: 'raisonSociale', keyId: 'id', specific: true});
     this.initStructureFilter();
   }
 

--- a/src/frontend/src/app/components/convention-create-en-masse/service-accueil-groupe/service-accueil-groupe.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/service-accueil-groupe/service-accueil-groupe.component.ts
@@ -60,9 +60,12 @@ export class ServiceAccueilGroupeComponent implements OnInit, OnChanges {
   }
 
   initStructureFilter(): void {
-    if (this.groupeEtudiant && this.groupeEtudiant.convention.structure) {
-      this.structures = this.groupeEtudiant.etudiantGroupeEtudiants.map((e: any) => e.convention.structure ?? this.groupeEtudiant.convention.structure);
-      this.structures = [...new Map(this.structures.map(e => [e.id, {id: e.id, raisonSociale: e.raisonSociale}])).values()];
+    if (this.groupeEtudiant) {
+      this.structures = [...new Map(this.groupeEtudiant.etudiantGroupeEtudiants
+        .map((e: any) => e.convention.structure ?? this.groupeEtudiant.convention.structure)
+        .filter((e: any) => !!e)
+        .map((e: any) => [e.id, {id: e.id, raisonSociale: e.raisonSociale}])
+      ).values()];
       let filter = this.filters.find((f: any) => f.id === 'convention.structure.id');
       if (filter) filter.options = this.structures;
     }

--- a/src/frontend/src/app/components/convention-create-en-masse/signataire-groupe/signataire-groupe.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/signataire-groupe/signataire-groupe.component.ts
@@ -50,7 +50,7 @@ export class SignataireGroupeComponent implements OnInit, OnChanges {
     this.columns.push('signataire')
     this.filters = [...this.sharedData.filters];
     this.filters.push({ id: 'convention.structure.id', libelle: 'Structure d\'accueil', type: 'list', options: [], keyLibelle: 'raisonSociale', keyId: 'id', specific: true});
-    this.filters.push({ id: 'convention.service.id', libelle: 'Service d\'accueil', type: 'list', options: [], keyLibelle: 'nom', keyId: 'id'});
+    this.filters.push({ id: 'convention.service.id', libelle: 'Service d\'accueil', type: 'list', options: [], keyLibelle: 'nom', keyId: 'id', specific: true});
     this.initStructureFilter();
     this.initServiceFilters();
   }

--- a/src/frontend/src/app/components/convention-create-en-masse/signataire-groupe/signataire-groupe.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/signataire-groupe/signataire-groupe.component.ts
@@ -49,7 +49,7 @@ export class SignataireGroupeComponent implements OnInit, OnChanges {
     this.columns.push('service')
     this.columns.push('signataire')
     this.filters = [...this.sharedData.filters];
-    this.filters.push({ id: 'convention.structure.id', libelle: 'Structure d\'accueil', type: 'list', options: [], keyLibelle: 'raisonSociale', keyId: 'id'});
+    this.filters.push({ id: 'convention.structure.id', libelle: 'Structure d\'accueil', type: 'list', options: [], keyLibelle: 'raisonSociale', keyId: 'id', specific: true});
     this.filters.push({ id: 'convention.service.id', libelle: 'Service d\'accueil', type: 'list', options: [], keyLibelle: 'nom', keyId: 'id'});
     this.initStructureFilter();
     this.initServiceFilters();

--- a/src/frontend/src/app/components/convention-create-en-masse/tuteur-accueil-groupe/tuteur-accueil-groupe.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/tuteur-accueil-groupe/tuteur-accueil-groupe.component.ts
@@ -75,9 +75,12 @@ export class TuteurAccueilGroupeComponent implements OnInit, OnChanges {
   }
 
   initServiceFilters(): void {
-    if (this.groupeEtudiant && this.groupeEtudiant.convention.structure && this.groupeEtudiant.convention.service) {
-      this.services = this.groupeEtudiant.etudiantGroupeEtudiants.map((e: any) => e.convention.service ?? this.groupeEtudiant.convention.service);
-      this.services = [...new Map(this.services.map(e => [e.id, {id: e.id, nom: e.nom}])).values()];
+    if (this.groupeEtudiant) {
+      this.services = [...new Map(this.groupeEtudiant.etudiantGroupeEtudiants
+        .map((e: any) => e.convention.service ?? this.groupeEtudiant.convention.service)
+        .filter((e: any) => !!e)
+        .map((e: any) => [e.id, {id: e.id, nom: e.nom}])
+      ).values()];
       let filter = this.filters.find((f: any) => f.id === 'convention.service.id');
       if (filter) filter.options = this.services;
     }

--- a/src/frontend/src/app/components/convention-create-en-masse/tuteur-accueil-groupe/tuteur-accueil-groupe.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/tuteur-accueil-groupe/tuteur-accueil-groupe.component.ts
@@ -49,7 +49,7 @@ export class TuteurAccueilGroupeComponent implements OnInit, OnChanges {
     this.columns.push('service')
     this.columns.push('contact')
     this.filters = [...this.sharedData.filters];
-    this.filters.push({ id: 'convention.structure.id', libelle: 'Structure d\'accueil', type: 'list', options: [], keyLibelle: 'raisonSociale', keyId: 'id'});
+    this.filters.push({ id: 'convention.structure.id', libelle: 'Structure d\'accueil', type: 'list', options: [], keyLibelle: 'raisonSociale', keyId: 'id', specific: true});
     this.filters.push({ id: 'convention.service.id', libelle: 'Service d\'accueil', type: 'list', options: [], keyLibelle: 'nom', keyId: 'id'});
     this.initStructureFilter();
     this.initServiceFilters();

--- a/src/frontend/src/app/components/convention-create-en-masse/tuteur-accueil-groupe/tuteur-accueil-groupe.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/tuteur-accueil-groupe/tuteur-accueil-groupe.component.ts
@@ -63,9 +63,12 @@ export class TuteurAccueilGroupeComponent implements OnInit, OnChanges {
   }
 
   initStructureFilter(): void {
-    if (this.groupeEtudiant && this.groupeEtudiant.convention.structure && this.groupeEtudiant.convention.service) {
-      this.structures = this.groupeEtudiant.etudiantGroupeEtudiants.map((e: any) => e.convention.structure ?? this.groupeEtudiant.convention.structure);
-      this.structures = [...new Map(this.structures.map(e => [e.id, {id: e.id, raisonSociale: e.raisonSociale}])).values()];
+    if (this.groupeEtudiant) {
+      this.structures = [...new Map(this.groupeEtudiant.etudiantGroupeEtudiants
+        .map((e: any) => e.convention.structure ?? this.groupeEtudiant.convention.structure)
+        .filter((e: any) => !!e)
+        .map((e: any) => [e.id, {id: e.id, raisonSociale: e.raisonSociale}])
+      ).values()];
       let filter = this.filters.find((f: any) => f.id === 'convention.structure.id');
       if (filter) filter.options = this.structures;
     }

--- a/src/frontend/src/app/components/convention-create-en-masse/tuteur-accueil-groupe/tuteur-accueil-groupe.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/tuteur-accueil-groupe/tuteur-accueil-groupe.component.ts
@@ -50,7 +50,7 @@ export class TuteurAccueilGroupeComponent implements OnInit, OnChanges {
     this.columns.push('contact')
     this.filters = [...this.sharedData.filters];
     this.filters.push({ id: 'convention.structure.id', libelle: 'Structure d\'accueil', type: 'list', options: [], keyLibelle: 'raisonSociale', keyId: 'id', specific: true});
-    this.filters.push({ id: 'convention.service.id', libelle: 'Service d\'accueil', type: 'list', options: [], keyLibelle: 'nom', keyId: 'id'});
+    this.filters.push({ id: 'convention.service.id', libelle: 'Service d\'accueil', type: 'list', options: [], keyLibelle: 'nom', keyId: 'id', specific: true});
     this.initStructureFilter();
     this.initServiceFilters();
   }

--- a/src/main/java/org/esup_portail/esup_stage/repository/EtudiantGroupeEtudiantRepository.java
+++ b/src/main/java/org/esup_portail/esup_stage/repository/EtudiantGroupeEtudiantRepository.java
@@ -38,6 +38,13 @@ public class EtudiantGroupeEtudiantRepository extends PaginationRepository<Etudi
             }
             clauses.add("(" + String.join(" OR ", clauseOr) + ")");
         }
+        if (key.equals("convention.structure.id")) {
+            clauses.add("(" +
+                    "ege.convention.structure.id IN :structureId" +
+                    " OR (ege.convention.structure.id IS NULL" +
+                        " AND ege.groupeEtudiant.convention.structure.id IN :structureId)" +
+                ")");
+        }
     }
 
     @Override
@@ -58,6 +65,9 @@ public class EtudiantGroupeEtudiantRepository extends PaginationRepository<Etudi
                 query.setParameter("codeUfr" + i, jsonUfrId.getString("code"));
                 query.setParameter("codeUnivUfr" + i, jsonUfrId.getString("codeUniversite"));
             }
+        }
+        if (key.equals("convention.structure.id")) {
+            query.setParameter("structureId", parameter.getJSONArray("value").toList());
         }
     }
 }

--- a/src/main/java/org/esup_portail/esup_stage/repository/EtudiantGroupeEtudiantRepository.java
+++ b/src/main/java/org/esup_portail/esup_stage/repository/EtudiantGroupeEtudiantRepository.java
@@ -45,6 +45,13 @@ public class EtudiantGroupeEtudiantRepository extends PaginationRepository<Etudi
                         " AND ege.groupeEtudiant.convention.structure.id IN :structureId)" +
                 ")");
         }
+        if (key.equals("convention.service.id")) {
+            clauses.add("(" +
+                    "ege.convention.service.id IN :serviceId" +
+                    " OR (ege.convention.service.id IS NULL" +
+                    " AND ege.groupeEtudiant.convention.service.id IN :serviceId)" +
+                    ")");
+        }
     }
 
     @Override
@@ -68,6 +75,9 @@ public class EtudiantGroupeEtudiantRepository extends PaginationRepository<Etudi
         }
         if (key.equals("convention.structure.id")) {
             query.setParameter("structureId", parameter.getJSONArray("value").toList());
+        }
+        if (key.equals("convention.service.id")) {
+            query.setParameter("serviceId", parameter.getJSONArray("value").toList());
         }
     }
 }


### PR DESCRIPTION
## Description / Objectif / Motivation / Contexte
<!-- Pourquoi ce changement est-il important ?
    Quel problème résout-il ?
    Veuillez inclure un résumé des modifications et du problème associé.
    Veuillez également inclure la motivation et le contexte pertinent.
    Énumérez toutes les dépendances requises par ce changement.
-->
Dans la gestion des conventions en masse, dans les onglets “service d'accueil” et “tuteur”,
les filtres sur la structure et/ou le service :
* n'incluent pas les saisies pour tout le groupe,
* sont alimentés uniquement si une saisie a été faite pour tout le groupe.

Cette PR propose de :
* rechercher aussi sur la convention du groupe en plus de celle de l'étudiant,
* alimenter les valeurs de liste déroulante même sans saisie pour tout le groupe.

<!--- Si vous suggérez une nouvelle fonctionnalité ou un changement,
      merci d'ouvrir un ticket (issue) avant -->
Ticket: Fixes #598

## Cas d'acceptance (Comment cela a-t-il été testé ?)
<!-- ou lien https://... vers ticket avec les cas de test
Si vous corrigez un⋅e bogue, il devrait y avoir un ticket
le décrivant avec des étapes pour le reproduire -->

<!--
Veuillez décrire les tests que vous avez effectués pour vérifier vos modifications.
Fournir des instructions pour que nous puissions reproduire.
Veuillez également énumérer tous les détails pertinents de votre configuration de test.
-->

- Étant donné une composante _COMP_ et une étape _ETAPE_ avec deux étudiantes Estelle et Lucie
- Étant donné une établissement d'accueil _STUCTURE_ et un service _SERVICE_
- Quand je suis sur la page _Créer des conventions en masse_
- Quand je saisis un code de groupe _COD_GROUPE_ et un nom de groupe _nom_du_groupe_
- Quand je choisis la composante _COMP_ et l'étape _ETAPE_
- Quand je sélectionne les étudiantes Estelle et Lucie
- Quand je clique sur l'action Valider (sous le code du groupe)
- Quand je vais à l'onglet “Etab. d'accueil”
- Quand je sélectionne les deux étudiantes
- Quand je clique sur “pour les étudiants sélectionnés”
- Quand je sélectionne l'établissement _STUCTURE_
- Quand je vais à l'onglet “Service d'accueil”
- Quand je clique sur “Structure d'accueil” dans “Sélection des étudiants du groupe”
- Alors la liste déroulante affiche _STUCTURE_
- Quand je vais à l'onglet “Etab. d'accueil”
- Quand je sélectionne les deux étudiantes
- Quand je clique sur “pour le groupe d'étudiant”
- Quand je sélectionne l'établissement _STUCTURE_
- Quand je vais à l'onglet “Etab. d'accueil”
- Quand je choisis _STUCTURE_ pour “Structure d'accueil” dans “Sélection des étudiants du groupe”
- Alors je vois les deux étudiantes Estelle et Lucie dans la liste
- Quand je sélectionne les deux étudiantes
- Quand je clique sur “pour les étudiants sélectionnés”
- Quand je sélectionne le service _SERVICE_
- Quand je vais à l'onglet “Tuteur professionnel”
- Alors la liste déroulante Structure d'accueil affiche _STUCTURE_
- Alors la liste déroulante Service d'accueil affiche _SERVICE_
- Quand je choisis _STRUCTURE_ dans le filtre Structure d'accueil
- Alors je vois les deux étudiantes Estelle et Lucie dans la liste
- Quand je choisis _SERVICE_ dans le filtre Service d'accueil
- Alors je vois les deux étudiantes Estelle et Lucie dans la liste

<!-- Mentionnez s'il y a des tests automatisés pour ce changement 🙏 -->
<!-- Joindre des captures d'écran (le cas échéant) -->
### Tests automatisés
* aucun

## Type

<!--Veuillez supprimer des options qui ne sont pas pertinentes.-->
- 🗹 Correction de bogue (modification non cassante qui résout un problème).
- ~☐ Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).~
- ~☐ Changement cassant (correction qui entraînerait la/une fonctionnalité existante à ne pas fonctionner comme précédemment).~
- ~☐ Changement nécessitant une mise à jour de la documentation utilisateur.~

## Definition du fini

- [ ] Les cas d'acceptance ci-dessus ont été vérifiés.
- [ ] Revue par au moins un⋅e relecteur⋅ice autorisé⋅e.
- ~☐ Documentation(s) mise(s) à jour (utilisateur, technique, commentaires de code compris).~
- ~☐ Si des changements _cassants_ sont introduits, ils sont dûment décrits
  et les étapes de montée de version décrites (éventuellement scriptés).~