### PR TITLE
issue #462 - conventions en masse(etab. d'accueil): préselection du service si possible

### DIFF
--- a/src/frontend/src/app/components/convention-create-en-masse/etab-accueil-groupe/etab-accueil-groupe-modal/etab-accueil-groupe-modal.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/etab-accueil-groupe/etab-accueil-groupe-modal/etab-accueil-groupe-modal.component.ts
@@ -24,6 +24,6 @@ export class EtabAccueilGroupeModalComponent implements OnInit {
   }
 
   updateEtab(data: any): void {
-    this.dialogRef.close(data.id);
+    this.dialogRef.close(data);
   }
 }

--- a/src/frontend/src/app/components/convention-create-en-masse/etab-accueil-groupe/etab-accueil-groupe.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/etab-accueil-groupe/etab-accueil-groupe.component.ts
@@ -112,7 +112,7 @@ export class EtabAccueilGroupeComponent implements OnInit, OnChanges {
     const modalDialog = this.matDialog.open(EtabAccueilGroupeModalComponent, dialogConfig);
     modalDialog.afterClosed().subscribe(dialogResponse => {
       if (dialogResponse) {
-        this.updateEtab(this.groupeEtudiant.convention.id,dialogResponse)
+        this.updateEtab(this.groupeEtudiant.convention.id,dialogResponse.id)
           .pipe(
             mergeMap(convention => this.getServiceIfSingle(dialogResponse, this.groupeEtudiant.convention.centreGestion.id).pipe(
               mergeMap(service => this.updateService(convention,service)),
@@ -138,7 +138,7 @@ export class EtabAccueilGroupeComponent implements OnInit, OnChanges {
           ).pipe(shareReplay(1));
         from(this.selected).pipe(
           mergeMap((etu) =>
-            this.updateEtab(etu.convention.id, dialogResponse)
+            this.updateEtab(etu.convention.id, dialogResponse.id)
           ),
           mergeMap(convention => service$.pipe(
             mergeMap(service => this.updateService(convention,service)),
@@ -172,8 +172,10 @@ export class EtabAccueilGroupeComponent implements OnInit, OnChanges {
         });
   }
 
-  getServiceIfSingle(etabId: number, centreGestionId: number): Observable<any> {
-    return this.serviceService.getByStructure(etabId, centreGestionId).pipe(
+  getServiceIfSingle(etab: any, centreGestionId: number): Observable<any> {
+    return this.serviceService.getByStructure(etab.id, centreGestionId).pipe(
+      map((response: any) => response.length === 1 ? response : response.filter(
+        (service:any) => service.nom === etab.raisonSociale)),
       filter((response: any) => response.length === 1),
       map((response: any) => response[0])
     );

--- a/src/frontend/src/app/components/convention-create-en-masse/etab-accueil-groupe/etab-accueil-groupe.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/etab-accueil-groupe/etab-accueil-groupe.component.ts
@@ -5,10 +5,21 @@ import { ConventionService } from "../../../services/convention.service";
 import { AuthService } from "../../../services/auth.service";
 import { Router } from "@angular/router";
 import { EtudiantGroupeEtudiantService } from "../../../services/etudiant-groupe-etudiant.service";
+import { ServiceService } from "../../../services/service.service";
 import { MessageService } from "../../../services/message.service";
 import { SortDirection } from "@angular/material/sort";
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { EtabAccueilGroupeModalComponent } from './etab-accueil-groupe-modal/etab-accueil-groupe-modal.component';
+import {
+  defaultIfEmpty, defer,
+  filter,
+  from,
+  map,
+  mergeMap,
+  Observable,
+  shareReplay,
+  tap, toArray,
+} from "rxjs";
 
 @Component({
   selector: 'app-etab-accueil-groupe',
@@ -33,6 +44,7 @@ export class EtabAccueilGroupeComponent implements OnInit, OnChanges {
     public groupeEtudiantService: GroupeEtudiantService,
     public etudiantGroupeEtudiantService: EtudiantGroupeEtudiantService,
     private conventionService: ConventionService,
+    private serviceService: ServiceService,
     private authService: AuthService,
     private router: Router,
     private messageService: MessageService,
@@ -101,6 +113,12 @@ export class EtabAccueilGroupeComponent implements OnInit, OnChanges {
     modalDialog.afterClosed().subscribe(dialogResponse => {
       if (dialogResponse) {
         this.updateEtab(this.groupeEtudiant.convention.id,dialogResponse)
+          .pipe(
+            mergeMap(convention => this.getServiceIfSingle(dialogResponse, this.groupeEtudiant.convention.centreGestion.id).pipe(
+              mergeMap(service => this.updateService(convention,service)),
+              defaultIfEmpty(convention),
+            ))
+          ).subscribe(convention => this.emitGroupe())
       }
     });
   }
@@ -115,9 +133,19 @@ export class EtabAccueilGroupeComponent implements OnInit, OnChanges {
     const modalDialog = this.matDialog.open(EtabAccueilGroupeModalComponent, dialogConfig);
     modalDialog.afterClosed().subscribe(dialogResponse => {
       if (dialogResponse) {
-        for(const etu of this.selected){
-          this.updateEtab(etu.convention.id,dialogResponse);
-        }
+        const service$ = defer(
+            () => this.getServiceIfSingle(dialogResponse, this.groupeEtudiant.convention.centreGestion.id)
+          ).pipe(shareReplay(1));
+        from(this.selected).pipe(
+          mergeMap((etu) =>
+            this.updateEtab(etu.convention.id, dialogResponse)
+          ),
+          mergeMap(convention => service$.pipe(
+            mergeMap(service => this.updateService(convention,service)),
+            defaultIfEmpty(convention),
+          )),
+          toArray(),
+        ).subscribe((conventions:any)=> this.emitGroupe());
       }
     });
   }
@@ -128,16 +156,35 @@ export class EtabAccueilGroupeComponent implements OnInit, OnChanges {
     });
   }
 
-  updateEtab(conventionId: number, etabId: number): void {
+  updateEtab(conventionId: number, etabId: number): Observable<any> {
     const data = {
       "field":'idStructure',
       "value":etabId,
     };
-    this.conventionService.patch(conventionId, data).subscribe((response: any) => {
+    return this.conventionService.patch(conventionId, data).pipe(tap((response: any) => {
         this.messageService.setSuccess('Structure d\'accueil affectée avec succès');
+    }));
+  }
+
+  emitGroupe() {
         this.groupeEtudiantService.getById(this.groupeEtudiant.id).subscribe((response: any) => {
           this.validated.emit(response);
         });
-    });
+  }
+
+  getServiceIfSingle(etabId: number, centreGestionId: number): Observable<any> {
+    return this.serviceService.getByStructure(etabId, centreGestionId).pipe(
+      filter((response: any) => response.length === 1),
+      map((response: any) => response[0])
+    );
+  }
+
+  updateService(convention: any, service: any): Observable<any> {
+    return this.conventionService.patch(convention.id, {
+      "field":'idService',
+      "value":service.id,
+    }).pipe(tap(convention =>
+        this.messageService.setSuccess('Service d\'accueil par défaut affectée avec succès')
+    ));
   }
 }


### PR DESCRIPTION
## Description / Objectif / Motivation / Contexte
<!-- Pourquoi ce changement est-il important ?
    Quel problème résout-il ?
    Veuillez inclure un résumé des modifications et du problème associé.
    Veuillez également inclure la motivation et le contexte pertinent.
    Énumérez toutes les dépendances requises par ce changement.
-->
Dans la gestion des conventions en masse,
le service d'accueil peut être présélectionné pour les gestionnaires
lorsque c'est possible.

Cette PR propose de présélectionner le service d'accueil s'il est unique ou s'il en existe un du même nom (par exemple les établissements scolaires).

<!--- Si vous suggérez une nouvelle fonctionnalité ou un changement,
      merci d'ouvrir un ticket (issue) avant -->
Ticket: Fixes #462

## Cas d'acceptance (Comment cela a-t-il été testé ?)
<!-- ou lien https://... vers ticket avec les cas de test
Si vous corrigez un⋅e bogue, il devrait y avoir un ticket
le décrivant avec des étapes pour le reproduire -->

<!--
Veuillez décrire les tests que vous avez effectués pour vérifier vos modifications.
Fournir des instructions pour que nous puissions reproduire.
Veuillez également énumérer tous les détails pertinents de votre configuration de test.
-->

- Étant donné une composante _COMP_ et une étape _ETAPE_ avec une étudiante Estelle
- Étant donné un établissement d'accueil _STRUCTURE_ et un service _SERVICE_
- Étant donné un établissement d'accueil _Établissement d'accueil_ et un service _Établissement d'accueil_ et un service _Autre Service_
- Quand je suis sur la page _Créer des conventions en masse_
- Quand je saisis un code de groupe _COD_GROUPE_ et un nom de groupe _nom_du_groupe_
- Quand je choisis la composante _COMP_ et l'étape _ETAPE_
- Quand je sélectionne l'étudiante Estelle
- Quand je clique sur l'action Valider (sous le code du groupe)
- Quand je suis sur l'onglet “établissement d'accueil”
- Quand j'affecte un établissement d'accueil _STRUCTURE_ pour tout le groupe
- Alors le service d'accueil _SERVICE_ est positionné pour Estelle
- Quand j'affecte un établissement d'accueil _Établissement d'accueil_ pour tout le groupe
- Alors le service d'accueil _Établissement d'accueil_ est positionné pour Estelle
- Quand j'affecte un établissement d'accueil _STRUCTURE_ à l'étudiante Estelle
- Alors le service d'accueil _SERVICE_ est positionné pour Estelle
- Quand j'affecte un établissement d'accueil _Établissement d'accueil_ à l'étudiante Estelle
- Alors le service d'accueil _Établissement d'accueil_ est positionné pour Estelle

<!-- Mentionnez s'il y a des tests automatisés pour ce changement 🙏 -->
<!-- Joindre des captures d'écran (le cas échéant) -->
### Tests automatisés
* aucun

## Type

<!--Veuillez supprimer des options qui ne sont pas pertinentes.-->
- ~☐ Correction de bogue (modification non cassante qui résout un problème).~
- 🗹 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
- ~☐ Changement cassant (correction qui entraînerait la/une fonctionnalité existante à ne pas fonctionner comme précédemment).~
- ~☐ Changement nécessitant une mise à jour de la documentation utilisateur.~

## Definition du fini

- [ ] Les cas d'acceptance ci-dessus ont été vérifiés.
- [ ] Revue par au moins un⋅e relecteur⋅ice autorisé⋅e.
- ~☐ Documentation(s) mise(s) à jour (utilisateur, technique, commentaires de code compris).~
- ~☐ Si des changements _cassants_ sont introduits, ils sont dûment décrits
  et les étapes de montée de version décrites (éventuellement scriptés).~