### PR TITLE
Release v3.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<description>Application ESUP-Stage</description>
 
 	<properties>
-		<revision>3.2.2</revision>
+		<revision>3.2.3</revision>
 		<sha1></sha1>
 		<changelist></changelist>
 

--- a/src/frontend/src/app/app.component.html
+++ b/src/frontend/src/app/app.component.html
@@ -7,7 +7,7 @@
       <li>
         <a class="fr-link" href="#menu">Menu</a>
       </li>
-      <li>
+      <li *ngIf="showFooter()">
         <a class="fr-link" href="#footer">Pied de page</a>
       </li>
     </ul>
@@ -42,4 +42,4 @@
     </main>
   </mat-sidenav-content>
 </mat-sidenav-container>
-<app-footer></app-footer>
+<app-footer *ngIf="showFooter()"></app-footer>

--- a/src/frontend/src/app/app.component.ts
+++ b/src/frontend/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { Droit } from "./constants/droit";
 import { environment } from "../environments/environment";
 import { ConfigService } from "./services/config.service";
 import { TechnicalService } from "./services/technical.service";
+import { Router } from "@angular/router";
 
 @Component({
     selector: 'app-root',
@@ -169,7 +170,8 @@ export class AppComponent {
     private configService: ConfigService,
     private el: ElementRef,
     private technicalService: TechnicalService,
-    public vcRef: ViewContainerRef
+    public vcRef: ViewContainerRef,
+    private router: Router
   ) {
     this.configService.getConfigTheme();
     this.configService.themeModified.subscribe((config: any) => {
@@ -188,6 +190,10 @@ export class AppComponent {
 
   isConnected() {
     return this.authService.userConnected;
+  }
+
+  showFooter(): boolean {
+    return !this.router.url.split('?')[0].startsWith('/evaluation-tuteur');
   }
 
   slideNavbar(): void {

--- a/src/frontend/src/app/components/convention/convention.component.ts
+++ b/src/frontend/src/app/components/convention/convention.component.ts
@@ -190,7 +190,7 @@ export class ConventionComponent implements OnInit {
   }
 
   updateStage(data: any): void {
-    this.updateSingleField(data.field,data.value);
+    this.updateSingleField(data.field, data.value, data.dureeExceptionnellePeriode);
   }
 
   updateEnseignant(data: any): void {
@@ -205,11 +205,14 @@ export class ConventionComponent implements OnInit {
   }
 
 
-  updateSingleField(key: string, value: any): void {
-    const data = {
+  updateSingleField(key: string, value: any, dureeExceptionnellePeriode?: string): void {
+    const data: any = {
       "field":key,
       "value":value,
     };
+    if (dureeExceptionnellePeriode != null) {
+      data.dureeExceptionnellePeriode = dureeExceptionnellePeriode;
+    }
     this.conventionService.patch(this.convention.id, data).subscribe((response: any) => {
       this.convention = response;
       this.majStatus();

--- a/src/frontend/src/app/components/convention/stage/stage.component.ts
+++ b/src/frontend/src/app/components/convention/stage/stage.component.ts
@@ -441,7 +441,7 @@ export class StageComponent implements OnInit {
   }
 
   updateDateFinBounds(dateDebut: Date): void {
-    this.minDateFinStage = new Date(dateDebut.getTime() + (1000 * 60 * 60 * 24));
+    this.minDateFinStage = new Date(dateDebut);
     this.maxDateFinStage = new Date(dateDebut.getTime() + (1000 * 60 * 60 * 24 * 365));
     this.form.get('dateFinStage')!.markAsTouched();
     this.form.get('dateFinStage')!.updateValueAndValidity();

--- a/src/frontend/src/app/components/convention/stage/stage.component.ts
+++ b/src/frontend/src/app/components/convention/stage/stage.component.ts
@@ -96,6 +96,7 @@ export class StageComponent implements OnInit {
   singleFieldUpdateQueue : any[] = [];
   updatingPeriode = false;
   initialLoading: boolean = true;
+  private readonly periodeStageFields = ['periodeStageMois', 'periodeStageJours', 'periodeStageHeures'];
 
   @Output() validated = new EventEmitter<number>();
   @Output() updateField = new EventEmitter<any>();
@@ -266,7 +267,10 @@ export class StageComponent implements OnInit {
 
     this.previousValues={...this.form.value}
     this.form.valueChanges.pipe(debounceTime(1000)).subscribe(res=>{
-      const keys=Object.keys(res).filter(k=>res[k]!=this.previousValues[k])
+      let keys=Object.keys(res).filter(k=>res[k]!=this.previousValues[k])
+      if (keys.includes('dureeExceptionnelle')) {
+        keys = keys.filter(k => !this.periodeStageFields.includes(k));
+      }
       this.previousValues={...this.form.value}
       keys.forEach((key: string) => {
         if (['interruptionStage','horairesReguliers','nbHeuresHebdo'].includes(key)){
@@ -331,7 +335,7 @@ export class StageComponent implements OnInit {
     this.singleFieldUpdateLock = false;
     if(this.singleFieldUpdateQueue.length > 0){
       const data = this.singleFieldUpdateQueue.shift();
-      this.updateSingleField(data.field,data.value);
+      this.updateSingleField(data.field, data.value, data.dureeExceptionnellePeriode);
     } else if (this.form) {
       this.validateForm();
     }
@@ -356,20 +360,24 @@ export class StageComponent implements OnInit {
     return this.convention?.centreGestion?.autoriserChevauchement === true;
   }
 
-  updateSingleField(key: string,value: any): void {
+  updateSingleField(key: string, value: any, dureeExceptionnellePeriode?: string): void {
     if (this.form.get(key)!.valid) {
-      const data = {
-        "field":key,
-        "value":value,
-      };
-      if (!this.singleFieldUpdateLock){
-        this.singleFieldUpdateLock = true;
-        this.updateField.emit(data);
-        if (key === 'dureeExceptionnelle' || key === 'periodeStageMois' || key === 'periodeStageJours' || key === 'periodeStageHeures') {
-          this.updateDureeStage();
+      if (this.periodeStageFields.includes(key)) {
+        this.updateDureeStage();
+      } else {
+        const data: any = {
+          "field":key,
+          "value":value,
+        };
+        if (key === 'dureeExceptionnelle') {
+          data.dureeExceptionnellePeriode = dureeExceptionnellePeriode ?? this.getDureeStageString();
         }
-      }else{
-        this.singleFieldUpdateQueue.push(data);
+        if (!this.singleFieldUpdateLock){
+          this.singleFieldUpdateLock = true;
+          this.updateField.emit(data);
+        }else{
+          this.singleFieldUpdateQueue.push(data);
+        }
       }
     }
     if (this.singleFieldUpdateLock || this.singleFieldUpdateQueue.length > 0) {
@@ -802,8 +810,12 @@ export class StageComponent implements OnInit {
     }
   }
 
+  getDureeStageString(): string {
+    return `${this.dureeStage.dureeMois} mois ${this.dureeStage.dureeJours} jour(s) ${this.dureeStage.dureeHeures} heure(s)`;
+  }
+
   updateDureeStage(): void {
-    const dureeString = `${this.dureeStage.dureeMois} mois ${this.dureeStage.dureeJours} jour(s) ${this.dureeStage.dureeHeures} heure(s)`;
+    const dureeString = this.getDureeStageString();
     this.conventionService.updatePeriodes(this.convention.id, dureeString)
       .subscribe({
         next: (response) => {

--- a/src/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/src/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -29,8 +29,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
   filters: any[] = [];
   validationsOptions: any[] = [
     { id: 'validationPedagogique', libelle: 'Validée pédagogiquement' },
+    { id: 'verificationAdministrative', libelle: 'Vérifiée administrativement' },
     { id: 'validationConvention', libelle: 'Validée administrativement' },
     { id: 'nonValidationPedagogique', libelle: 'Non validée pédagogiquement' },
+    { id: 'nonVerificationAdministrative', libelle: 'Non vérifiée administrativement' },
     { id: 'nonValidationConvention', libelle: 'Non validée administrativement' },
     { id: 'signe', libelle: 'Signé' },
     { id: 'enCours', libelle: 'En cours de signature' },

--- a/src/frontend/src/app/components/evaluation-tuteur/evaluation-tuteur.component.ts
+++ b/src/frontend/src/app/components/evaluation-tuteur/evaluation-tuteur.component.ts
@@ -28,8 +28,12 @@ export class EvaluationTuteurComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    // Récupérer le token depuis les query params uniquement
-    this.token = this.route.snapshot.queryParams['token'];
+    // Recuperer le token depuis l'URL ou la session de navigation.
+    this.token = this.getTokenFromUrl() || this.ctx.getStoredToken();
+    if (this.token) {
+      this.ctx.setToken(this.token);
+      this.ensureTokenInUrl();
+    }
     // Valider immédiatement le token et, si OK, naviguer vers l'accueil
     this.validateTokenAndRedirect();
   }
@@ -39,7 +43,7 @@ export class EvaluationTuteurComponent implements OnInit {
    */
   private validateTokenAndRedirect(): void {
     if (!this.token){
-      this.messageService.setError("Token manquant dans l'URL");
+      this.messageService.setError("Token manquant ou session expiree");
       return;
     }
 
@@ -52,14 +56,44 @@ export class EvaluationTuteurComponent implements OnInit {
         this.convention = convention;
         this.ctx.setToken(this.token);
         this.ctx.setConvention(convention);
-        this.router.navigate(['/evaluation-tuteur', convention.id], {
-          queryParams: { token: this.token }
-        });
+        if (this.isRootEvaluationUrl()) {
+          this.router.navigate(['/evaluation-tuteur', convention.id], {
+            queryParams: { token: this.token }
+          });
+        }
       },
       error: (error) => {
         this.isLoading = false;
+        this.ctx.setToken(null);
         console.error('Erreur lors de la validation du token:', error);
       }
     });
+  }
+
+  private getTokenFromUrl(): string | null {
+    const routeToken = this.route.snapshot.queryParamMap.get('token') || this.route.snapshot.queryParams['token'];
+    if (routeToken) return routeToken;
+
+    const searchToken = new URLSearchParams(window.location.search).get('token');
+    if (searchToken) return searchToken;
+
+    const hash = window.location.hash;
+    const queryIndex = hash.indexOf('?');
+    if (queryIndex === -1) return null;
+
+    return new URLSearchParams(hash.substring(queryIndex + 1)).get('token');
+  }
+
+  private ensureTokenInUrl(): void {
+    if (this.route.snapshot.queryParamMap.get('token')) return;
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { token: this.token },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+  }
+  private isRootEvaluationUrl(): boolean {
+    return this.router.url.split('?')[0] === '/evaluation-tuteur';
   }
 }

--- a/src/frontend/src/app/components/evaluation-tuteur/pages/accueil-tuteur/accueil-tuteur.component.ts
+++ b/src/frontend/src/app/components/evaluation-tuteur/pages/accueil-tuteur/accueil-tuteur.component.ts
@@ -29,6 +29,7 @@ export class AccueilTuteurComponent implements OnInit {
     this.router.navigate(['questionnaire'],
       {
         relativeTo: this.route,
+        queryParamsHandling: 'preserve',
       });
   }
 }

--- a/src/frontend/src/app/components/evaluation-tuteur/pages/questionnaire-complet-tuteur/questionnaire-complet-tuteur.component.ts
+++ b/src/frontend/src/app/components/evaluation-tuteur/pages/questionnaire-complet-tuteur/questionnaire-complet-tuteur.component.ts
@@ -48,6 +48,7 @@ export class QuestionnaireCompletTuteurComponent implements OnInit{
   }
 
   imprimer(){
+    if (!this.canUseToken()) return;
     this.evaluationTuteurService.getEvaluationPDF(this.token,this.convention.id).subscribe(r=>{
       var blob = new Blob([r as BlobPart], {type: "application/pdf"});
       let filename = 'Questionnaire_'+this.convention.id + '.pdf';
@@ -56,10 +57,19 @@ export class QuestionnaireCompletTuteurComponent implements OnInit{
   }
 
   renouvellement() {
+    if (!this.canUseToken()) return;
     this.evaluationTuteurService.getReouvellement(this.token,this.convention.id).subscribe(
       r => {
-        this.messageService.setSuccess('Renouvellement effectué avec succès.');
+        this.messageService.setSuccess('Renouvellement effectue avec succes.');
       }
     )
+  }
+
+  canUseToken(): boolean {
+    if (!this.token || !this.convention) {
+      this.messageService.setError('Chargement de l\'evaluation en cours.');
+      return false;
+    }
+    return true;
   }
 }

--- a/src/frontend/src/app/components/evaluation-tuteur/pages/questionnaire-tuteur/questionnaire-tuteur.component.ts
+++ b/src/frontend/src/app/components/evaluation-tuteur/pages/questionnaire-tuteur/questionnaire-tuteur.component.ts
@@ -346,10 +346,12 @@ export class QuestionnaireTuteurComponent implements OnInit {
   terminer(): void {
     const valid = this.reponseEntrepriseForm.valid && this.reponseSupplementaireEntrepriseForm.valid;
     this.saveReponse();
-    this.evaluationTuteurService.validate(this.token, this.convention.id, valid).subscribe();
-    this.router.navigate(['/evaluation-tuteur', this.convention.id, 'terminee'], {
-      relativeTo: this.route.parent,
-      replaceUrl: true,
+    this.evaluationTuteurService.validate(this.token, this.convention.id, valid).subscribe(() => {
+      this.router.navigate(['/evaluation-tuteur', this.convention.id, 'terminee'], {
+        relativeTo: this.route.parent,
+        replaceUrl: true,
+        queryParamsHandling: 'preserve',
+      });
     });
   }
 

--- a/src/frontend/src/app/components/evaluation-tuteur/services/evaluation-tuteur-context.service.ts
+++ b/src/frontend/src/app/components/evaluation-tuteur/services/evaluation-tuteur-context.service.ts
@@ -12,6 +12,8 @@ import { ConventionEvaluationTuteur } from '../models/convention-evaluation-tute
  */
 @Injectable({ providedIn: 'root' })
 export class EvaluationTuteurContextService {
+  private readonly tokenStorageKey = 'evaluation-tuteur-token';
+
   /**
    * Sujet interne qui conserve la dernière valeur du token.
    */
@@ -37,7 +39,16 @@ export class EvaluationTuteurContextService {
    * @param t Nouveau token (ou `null` pour réinitialiser).
    */
   setToken(t: string | null): void {
+    if (t) {
+      sessionStorage.setItem(this.tokenStorageKey, t);
+    } else {
+      sessionStorage.removeItem(this.tokenStorageKey);
+    }
     this.tokenSubject.next(t);
+  }
+
+  getStoredToken(): string | null {
+    return sessionStorage.getItem(this.tokenStorageKey);
   }
 
   /**

--- a/src/main/java/org/esup_portail/esup_stage/controller/ConventionController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/ConventionController.java
@@ -812,7 +812,14 @@ public class  ConventionController {
         conventionService.canViewEditConvention(convention, ServiceContext.getUtilisateur());
 
         // Contrôle chevauchement de dates
-        return dateStageDto.getDateDebut() != null && dateStageDto.getDateFin() != null && conventionJpaRepository.findDatesChevauchent(convention.getEtudiant().getIdentEtudiant(), convention.getId(), dateStageDto.getDateDebut(), dateStageDto.getDateFin()).isEmpty();
+        return dateStageDto.getDateDebut() != null
+                && dateStageDto.getDateFin() != null
+                && !conventionJpaRepository.findDatesChevauchent(
+                        convention.getEtudiant().getIdentEtudiant(),
+                        convention.getId(),
+                        dateStageDto.getDateDebut(),
+                        dateStageDto.getDateFin()
+                ).isEmpty();
     }
 
     private void validationPedagogique(Convention convention, ConfigAlerteMailDto configAlerteMailDto, Utilisateur utilisateurContext, boolean valider) {

--- a/src/main/java/org/esup_portail/esup_stage/controller/ConventionController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/ConventionController.java
@@ -661,6 +661,9 @@ public class  ConventionController {
         }
         if (Objects.equals(conventionSingleFieldDto.getField(), "dureeExceptionnelle")) {
             convention.setDureeExceptionnelle(conventionSingleFieldDto.getValue().toString());
+            if (conventionSingleFieldDto.getDureeExceptionnellePeriode() != null) {
+                convention.setDureeExceptionnellePeriode(conventionSingleFieldDto.getDureeExceptionnellePeriode());
+            }
         }
         if (Objects.equals(conventionSingleFieldDto.getField(), "idTempsTravail")) {
             TempsTravail tempsTravail = tempsTravailJpaRepository.findById((int) conventionSingleFieldDto.getValue());

--- a/src/main/java/org/esup_portail/esup_stage/controller/EvaluationTuteurController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/EvaluationTuteurController.java
@@ -65,7 +65,7 @@ public class EvaluationTuteurController {
 
         parseJwtOrThrow(token);
 
-        EvaluationTuteurToken validToken = evaluationService.validateToken(token);
+        EvaluationTuteurToken validToken = evaluationService.getToken(token);
         if (validToken == null) {
             warnInvalid(token);
             throw new AppException(HttpStatus.FORBIDDEN, "Token invalide ou expiré");

--- a/src/main/java/org/esup_portail/esup_stage/dto/ConventionSingleFieldDto.java
+++ b/src/main/java/org/esup_portail/esup_stage/dto/ConventionSingleFieldDto.java
@@ -9,6 +9,8 @@ public class ConventionSingleFieldDto {
 
     private Object value;
 
+    private String dureeExceptionnellePeriode;
+
     public String getField() {
         return field;
     }
@@ -23,5 +25,13 @@ public class ConventionSingleFieldDto {
 
     public void setValue(Object value) {
         this.value = value;
+    }
+
+    public String getDureeExceptionnellePeriode() {
+        return dureeExceptionnellePeriode;
+    }
+
+    public void setDureeExceptionnellePeriode(String dureeExceptionnellePeriode) {
+        this.dureeExceptionnellePeriode = dureeExceptionnellePeriode;
     }
 }

--- a/src/main/java/org/esup_portail/esup_stage/dto/MetadataSignataireDto.java
+++ b/src/main/java/org/esup_portail/esup_stage/dto/MetadataSignataireDto.java
@@ -2,7 +2,6 @@ package org.esup_portail.esup_stage.dto;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
-import org.apache.logging.log4j.util.Strings;
 
 @Data
 public class MetadataSignataireDto {
@@ -21,6 +20,6 @@ public class MetadataSignataireDto {
     private int order;
 
     public String getPhone() {
-        return Strings.isEmpty(phone) ? null : phone;
+        return phone != null && !phone.equals("null") ? phone : "";
     }
 }

--- a/src/main/java/org/esup_portail/esup_stage/repository/ConventionRepository.java
+++ b/src/main/java/org/esup_portail/esup_stage/repository/ConventionRepository.java
@@ -99,11 +99,17 @@ public class ConventionRepository extends PaginationRepository<Convention> {
                     case "validationConvention":
                         clauseAnd.add("c.validationConvention = TRUE");
                         break;
+                    case "verificationAdministrative":
+                        clauseAnd.add("c.verificationAdministrative = TRUE");
+                        break;
                     case "nonValidationPedagogique":
                         clauseAnd.add("c.validationPedagogique = FALSE");
                         break;
                     case "nonValidationConvention":
                         clauseAnd.add("c.validationConvention = FALSE");
+                        break;
+                    case "nonVerificationAdministrative":
+                        clauseAnd.add("c.verificationAdministrative = FALSE");
                         break;
                     case "signe":
                         clauseAnd.add("c.dateSignatureEnseignant IS NOT NULL AND c.dateSignatureEtudiant IS NOT NULL AND c.dateSignatureSignataire IS NOT NULL AND c.dateSignatureTuteur IS NOT NULL AND c.dateSignatureViseur IS NOT NULL");

--- a/src/main/java/org/esup_portail/esup_stage/repository/ConventionRepository.java
+++ b/src/main/java/org/esup_portail/esup_stage/repository/ConventionRepository.java
@@ -48,7 +48,7 @@ public class ConventionRepository extends PaginationRepository<Convention> {
             for (int i = 0; i < jsonArray.size(); ++i) {
                 clauseOr.add("(c.etape.id.code = :codeEtape" + i + " AND c.etape.id.codeUniversite = :codeUnivEtape" + i + " AND c.etape.id.codeVersionEtape = :versionEtape" + i + ")");
             }
-            if (clauseOr.isEmpty()) {
+            if (!clauseOr.isEmpty()) {
                 clauses.add("(" + String.join(" OR ", clauseOr) + ")");
             }
         }
@@ -118,7 +118,7 @@ public class ConventionRepository extends PaginationRepository<Convention> {
                         break;
                 }
             }
-            if (clauseAnd.isEmpty()) {
+            if (!clauseAnd.isEmpty()) {
                 clauses.add("(" + String.join(" AND ", clauseAnd) + ")");
             }
         }

--- a/src/main/java/org/esup_portail/esup_stage/service/MailerService.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/MailerService.java
@@ -52,9 +52,6 @@ public class MailerService {
     TemplateMailGroupeJpaRepository templateMailGroupeJpaRepository;
 
     @Autowired
-    ApplicationProperties applicationProperties;
-
-    @Autowired
     EvaluationService evaluationService;
 
     @Autowired
@@ -83,7 +80,7 @@ public class MailerService {
         if (to == null || to.isEmpty() || to.equals("null")) {
             logger.info("Aucun destinataire défini pour l'envoie de l'email.");
         } else {
-            MailContext mailContext = new MailContext(appliProperties, applicationProperties,convention, avenant, userModif, evaluationService.buildEvaluationTuteurUrl(convention));
+            MailContext mailContext = new MailContext(appliProperties, convention, avenant, userModif, evaluationService.buildEvaluationTuteurUrl(convention));
             sendMail(to, templateMail.getId(), templateMail.getObjet(), templateMail.getTexte(), templateMail.getCode(),
                     mailContext, false, null, null);
         }
@@ -97,7 +94,7 @@ public class MailerService {
         if (to == null || to.isEmpty() || to.equals("null")) {
             logger.info("Aucun destinataire défini pour l'envoie de l'email.");
         } else {
-            MailContext mailContext = new MailContext(appliProperties, applicationProperties,convention, avenant, evaluationService.buildEvaluationTuteurUrl(convention));
+            MailContext mailContext = new MailContext(appliProperties, convention, avenant, evaluationService.buildEvaluationTuteurUrl(convention));
             sendMail(to, templateMail.getId(), templateMail.getObjet(), templateMail.getTexte(), templateMail.getCode(),
                     mailContext, false, null, null);
         }
@@ -111,7 +108,7 @@ public class MailerService {
         if (to == null || to.isEmpty()) {
             logger.info("Aucun destinataire défini pour l'envoie de l'email.");
         } else {
-            MailContext mailContext = new MailContext(appliProperties, applicationProperties,convention, null, userModif, evaluationService.buildEvaluationTuteurUrl(convention));
+            MailContext mailContext = new MailContext(appliProperties, convention, null, userModif, evaluationService.buildEvaluationTuteurUrl(convention));
             sendMail(to, templateMailGroupe.getId(), templateMailGroupe.getObjet(), templateMailGroupe.getTexte(), templateMailGroupe.getCode(),
                     mailContext, false, "conventions.zip", archive);
         }
@@ -128,7 +125,7 @@ public class MailerService {
             CentreGestion centreEtablissement = centreGestionJpaRepository.getCentreEtablissement();
             Convention convention = previewConventionFactory.createFictionalConvention(centreEtablissement);
             Avenant avenant = previewConventionFactory.createFictionalAvenant(convention);
-            MailContext mailContext = new MailContext(appliProperties, applicationProperties, convention, avenant, evaluationService.buildEvaluationTuteurUrl(convention));
+            MailContext mailContext = new MailContext(appliProperties, convention, avenant, evaluationService.buildEvaluationTuteurUrl(convention));
             if (mailContext.getSignataire() != null && mailContext.getSignataire().getTel() == null) {
                 mailContext.getSignataire().setTel("+33 1 44 55 66 77");
             }
@@ -308,9 +305,9 @@ public class MailerService {
         private AvenantContext avenant = new AvenantContext();
         private String lienEvaluationTuteur= "";
 
-        public MailContext(AppliProperties appliProperties,ApplicationProperties applicationProperties,Convention convention, Avenant avenant, Utilisateur userModif, String lienEvaluationTuteur) {
+        public MailContext(AppliProperties appliProperties, Convention convention, Avenant avenant, Utilisateur userModif, String lienEvaluationTuteur) {
             if (convention != null) {
-                this.convention = new ConventionContext(appliProperties, applicationProperties, convention);
+                this.convention = new ConventionContext(appliProperties, convention);
                 this.tuteurPro = new TuteurProContext(convention.getContact(), convention.getStructure(), convention.getService());
                 this.signataire = new SignataireContext(convention.getSignataire());
                 this.etudiant = new EtudiantContext(convention.getEtudiant(), convention.getCourrielPersoEtudiant(), convention.getTelEtudiant());
@@ -322,9 +319,9 @@ public class MailerService {
             this.modifiePar = new ModifieParContext(userModif);
         }
 
-        public MailContext(AppliProperties appliProperties,ApplicationProperties applicationProperties,Convention convention, Avenant avenant, String lienEvaluationTuteur) {
+        public MailContext(AppliProperties appliProperties, Convention convention, Avenant avenant, String lienEvaluationTuteur) {
             if (convention != null) {
-                this.convention = new ConventionContext(appliProperties, applicationProperties, convention);
+                this.convention = new ConventionContext(appliProperties, convention);
                 this.tuteurPro = new TuteurProContext(convention.getContact(), convention.getStructure(), convention.getService());
                 this.signataire = new SignataireContext(convention.getSignataire());
                 this.etudiant = new EtudiantContext(convention.getEtudiant(), convention.getCourrielPersoEtudiant(), convention.getTelEtudiant());
@@ -351,7 +348,7 @@ public class MailerService {
             private String tempsTravailComment;
             private String lien;
 
-            public ConventionContext(AppliProperties appliProperties,ApplicationProperties applicationProperties,Convention convention) {
+            public ConventionContext(AppliProperties appliProperties, Convention convention) {
                 DateFormat df = new SimpleDateFormat("dd/MM/yyyy");
 
                 this.numero = String.valueOf(convention.getId());

--- a/src/main/java/org/esup_portail/esup_stage/service/apogee/ApogeeService.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/apogee/ApogeeService.java
@@ -376,12 +376,22 @@ public class ApogeeService {
     public InfosAdmEtu getInfosAdmEtudiant(String numEtud) {
         Map<String, String> params = new HashMap<>();
         params.put("numEtud", numEtud);
-        String response = call("/infosAdmEtu", params);
+        String response;
+        try {
+            response = call("/infosAdmEtu", params);
+        } catch (AppException e) {
+            if (e.getHttpStatus() == HttpStatus.NOT_FOUND) {
+                LOGGER.info("Aucune donnée administrative trouvée pour l'étudiant {}", numEtud);
+                return null;
+            }
+            throw e;
+        }
+
         try {
             ObjectMapper mapper = new ObjectMapper();
             InfosAdmEtu infoAdmEtudiant = mapper.readValue(response, InfosAdmEtu.class);
             if (infoAdmEtudiant == null) {
-                LOGGER.info("Aucune donnée trouvée");
+                LOGGER.info("Aucune donnée administrative trouvée pour l'étudiant {}", numEtud);
             }
             return infoAdmEtudiant;
         } catch (JsonProcessingException e) {

--- a/src/main/java/org/esup_portail/esup_stage/service/impression/ImpressionService.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/impression/ImpressionService.java
@@ -271,16 +271,16 @@ public class ImpressionService {
         sb.append("<meta-data-list>");
         if (typeSignatureEnum == TypeSignatureEnum.otp) {
             for (int i = 0; i < otp.size(); ++i) {
-                sb.append("<meta-data name=\"OTP_firstname_").append(i).append("\" value=\"").append(otp.get(i).get(firstnameKey)).append("\"/>");
-                sb.append("<meta-data name=\"OTP_lastname_").append(i).append("\" value=\"").append(otp.get(i).get(lastnameKey)).append("\"/>");
-                sb.append("<meta-data name=\"OTP_phonenumber_").append(i).append("\" value=\"").append(otp.get(i).get(phoneNumberKey)).append("\"/>");
-                sb.append("<meta-data name=\"OTP_email_").append(i).append("\" value=\"").append(otp.get(i).get(emailKey)).append("\"/>");
+                sb.append("<meta-data name=\"OTP_firstname_").append(i).append("\" value=\"").append(xmlValue(otp.get(i).get(firstnameKey))).append("\"/>");
+                sb.append("<meta-data name=\"OTP_lastname_").append(i).append("\" value=\"").append(xmlValue(otp.get(i).get(lastnameKey))).append("\"/>");
+                sb.append("<meta-data name=\"OTP_phonenumber_").append(i).append("\" value=\"").append(xmlValue(otp.get(i).get(phoneNumberKey))).append("\"/>");
+                sb.append("<meta-data name=\"OTP_email_").append(i).append("\" value=\"").append(xmlValue(otp.get(i).get(emailKey))).append("\"/>");
             }
         } else {
             int counter = 1;
             for (String key : Arrays.asList(lastnameKey, firstnameKey, emailKey)) {
                 for (Map<String, String> stringStringMap : otp) {
-                    sb.append("<meta-data name=\"TEXT").append(String.format("%03d", counter++)).append("\" value=\"").append(stringStringMap.get(key)).append("\"/>");
+                    sb.append("<meta-data name=\"TEXT").append(String.format("%03d", counter++)).append("\" value=\"").append(xmlValue(stringStringMap.get(key))).append("\"/>");
                 }
             }
         }
@@ -341,7 +341,8 @@ public class ImpressionService {
         if (deliveryAddress != null && !deliveryAddress.isEmpty()  && !deliveryAddress.equals("null")) {
             return "";
         }
-        return conventionService.parseNumTel(phoneNumber);
+        String parsedPhoneNumber = conventionService.parseNumTel(phoneNumber);
+        return parsedPhoneNumber != null ? parsedPhoneNumber : "";
     }
 
     public String getOtpDataEmail(String email) {
@@ -349,7 +350,11 @@ public class ImpressionService {
         if (deliveryAddress != null && !deliveryAddress.isEmpty() && !deliveryAddress.equals("null")) {
             return deliveryAddress;
         }
-        return email != null ? email : "";
+        return xmlValue(email);
+    }
+
+    private String xmlValue(String value) {
+        return value != null && !value.equals("null") ? value : "";
     }
 
     public String manageIfElse(String text) {

--- a/src/main/java/org/esup_portail/esup_stage/service/signature/SignatureService.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/signature/SignatureService.java
@@ -200,7 +200,7 @@ public class SignatureService {
                     break;
             }
             if (signataireDto.getOrder() != 0) {
-                signataireDto.setPhone(conventionService.parseNumTel(phone));
+                signataireDto.setPhone(phone != null ? phone : "");
                 signataires.add(signataireDto);
             }
         });

--- a/src/main/resources/db/changelog/3.2.0-code-statut-juridique-2.yaml
+++ b/src/main/resources/db/changelog/3.2.0-code-statut-juridique-2.yaml
@@ -102,6 +102,7 @@ databaseChangeLog:
   - changeSet:
       id: 3.2.0-ajout-statuts-juridiques-niveau2
       author: thouveno9
+      validCheckSum: ANY
       comment: "Ajout des statuts juridiques avec codes niveau 2 INSEE (organismes publics + formes courantes)"
       changes:
         - sql:
@@ -109,109 +110,134 @@ databaseChangeLog:
               -- PERSONNES PHYSIQUES (Code 10)
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'Entrepreneur individuel', '10', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '10' OR libelleStatutJuridique = 'Entrepreneur individuel');
   
               -- SOCIÉTÉS COMMERCIALES
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'SNC', '52', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '52' OR libelleStatutJuridique = 'SNC');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'SCS', '53', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '53' OR libelleStatutJuridique = 'SCS');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'SARL', '54', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '54' OR libelleStatutJuridique = 'SARL');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'SA à conseil d''administration', '55', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '55' OR libelleStatutJuridique = 'SA à conseil d''administration');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'SA à directoire', '56', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '56' OR libelleStatutJuridique = 'SA à directoire');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'SAS', '57', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '57' OR libelleStatutJuridique = 'SAS');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'SE', '58', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '58' OR libelleStatutJuridique = 'SE');
   
               -- SOCIÉTÉS CIVILES
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'SCI', '60', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '60' OR libelleStatutJuridique = 'SCI');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'SCM', '61', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '61' OR libelleStatutJuridique = 'SCM');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'GIE', '62', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '62' OR libelleStatutJuridique = 'GIE');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'GEIE', '63', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '63' OR libelleStatutJuridique = 'GEIE');
   
               -- SOCIÉTÉS D'ASSURANCE
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'SAM', '64', 5, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '64' OR libelleStatutJuridique = 'SAM');
   
               -- SOCIÉTÉS CIVILES PROFESSIONNELLES
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'SCP', '65', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '65' OR libelleStatutJuridique = 'SCP');
   
               -- SOCIÉTÉS D'EXERCICE LIBÉRAL
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'SEL', '69', 3, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '69' OR libelleStatutJuridique = 'SEL');
   
               -- PERSONNES MORALES DE DROIT PUBLIC
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'Administration de l''état', '71', 1, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '71' OR libelleStatutJuridique = 'Administration de l''état');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'Collectivité territoriale', '72', 1, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '72' OR libelleStatutJuridique = 'Collectivité territoriale');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'EPA', '73', 1, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '73' OR libelleStatutJuridique = 'EPA');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'Autre personne morale de droit public administratif', '74', 1, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '74' OR libelleStatutJuridique = 'Autre personne morale de droit public administratif');
   
               -- ORGANISMES PRIVÉS SPÉCIALISÉS
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'Organisme de protection sociale', '81', 1, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '81' OR libelleStatutJuridique = 'Organisme de protection sociale');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'Organisme professionnel', '82', 2, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '82' OR libelleStatutJuridique = 'Organisme professionnel');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'Organisme de recherche', '83', 1, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '83' OR libelleStatutJuridique = 'Organisme de recherche');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'Syndicat de copropriété', '84', 2, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '84' OR libelleStatutJuridique = 'Syndicat de copropriété');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'Association', '92', 2, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '92' OR libelleStatutJuridique = 'Association');
   
               INSERT INTO StatutJuridique (libelleStatutJuridique, code, idTypeStructure, temEnServStatut)
               SELECT 'Congrégation', '93', 2, 'O'
+              FROM DUAL
               WHERE NOT EXISTS (SELECT 1 FROM StatutJuridique WHERE code = '93' OR libelleStatutJuridique = 'Congrégation');
 
             dbms: mysql,mariadb

--- a/src/main/resources/db/changelog/3.2.0-evaluation-stage.yaml
+++ b/src/main/resources/db/changelog/3.2.0-evaluation-stage.yaml
@@ -201,3 +201,15 @@ databaseChangeLog:
             tableName: EvaluationTuteurToken
             columnName: Token
             newDataType: VARCHAR(1024)
+  - changeSet:
+      id: 3.2.3-fix-evaluation-tuteur-token-dates
+      author: thouveno9
+      changes:
+        - modifyDataType:
+            tableName: EvaluationTuteurToken
+            columnName: DateExpiration
+            newDataType: DATETIME
+        - modifyDataType:
+            tableName: EvaluationTuteurToken
+            columnName: DateCreation
+            newDataType: DATETIME


### PR DESCRIPTION
- Autorise à nouveau la saisie de stages d'une durée de 1 jour en permettant une date de fin identique à la date de début.
- Corrige le filtre "État de validation de la convention" (issue #646)
- Corrige la sauvegarde de la durée effective du stage et de la durée en mois / jours / heures.
- Corrige la gestion du token sur l'espace public tuteur. ( issue #637) 
- Corrige l'erreur technique générée par le filtre Étape du tableau de bord.
- Corrige le contrôle de chevauchement de dates côté étudiant.
- Corrige le parsing des numéros de téléphone FAST.
- Corrige la migration MariaDB 10 liée aux codes de statut juridique. (issue #629)