### PR TITLE
Fix fin de session pendant l'édition d'un template

### DIFF
--- a/src/frontend/src/app/components/admin/template-convention/template-convention.component.ts
+++ b/src/frontend/src/app/components/admin/template-convention/template-convention.component.ts
@@ -8,6 +8,7 @@ import { LangueConventionService } from "../../../services/langue-convention.ser
 import { AppFonction } from "../../../constants/app-fonction";
 import { Droit } from "../../../constants/droit";
 import { AuthService } from "../../../services/auth.service";
+import { SessionKeepAliveService } from "../../../services/session-keep-alive.service";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { MatTabChangeEvent, MatTabGroup } from "@angular/material/tabs";
 import { TitleService } from "../../../services/title.service";
@@ -124,6 +125,7 @@ export class TemplateConventionComponent implements OnInit, AfterViewInit, OnDes
     private typeConventionService: TypeConventionService,
     private langueConventionService: LangueConventionService,
     private authService: AuthService,
+    private sessionKeepAlive: SessionKeepAliveService,
     private fb: FormBuilder,
     private titleService: TitleService,
     private changeDetector: ChangeDetectorRef
@@ -378,6 +380,16 @@ export class TemplateConventionComponent implements OnInit, AfterViewInit, OnDes
       this.form.get('typeConvention')?.disable();
       this.form.get('langueConvention')?.disable();
     }
+    // Keep-alive de session : actif uniquement sur les onglets d'édition longue
+    // (Création / Édition), arrêté sur la liste pour ne pas maintenir la session
+    // en vie inutilement.
+    if (event.index === this.createTabIndex || event.index === this.editTabIndex) {
+      // Intervalle 2 min : sûr même avec un timeout de session court (test à 3 min)
+      // comme en prod (timeout Spring par défaut 30 min).
+      this.sessionKeepAlive.start({ pingIntervalMs: 2 * 60 * 1000 });
+    } else {
+      this.sessionKeepAlive.stop();
+    }
   }
 
   canEdit(): boolean {
@@ -463,5 +475,6 @@ export class TemplateConventionComponent implements OnInit, AfterViewInit, OnDes
     if (this.editorRenderFrame) {
       cancelAnimationFrame(this.editorRenderFrame);
     }
+    this.sessionKeepAlive.stop();
   }
 }

--- a/src/frontend/src/app/interceptors/http-context.tokens.ts
+++ b/src/frontend/src/app/interceptors/http-context.tokens.ts
@@ -1,0 +1,13 @@
+import { HttpContextToken } from '@angular/common/http';
+
+/**
+ * Marque une requête comme « silencieuse ».
+ *
+ * Le TechnicalInterceptor n'affiche alors ni le loader plein écran ni la popup
+ * d'erreur générique : la requête reste totalement discrète et son résultat
+ * (succès comme erreur) est géré uniquement par l'appelant.
+ *
+ * Utilisé par le keep-alive de session (ping périodique de rafraîchissement)
+ * pour ne pas perturber l'utilisateur en cours de rédaction.
+ */
+export const SILENT_REQUEST = new HttpContextToken<boolean>(() => false);

--- a/src/frontend/src/app/interceptors/technical.interceptor.ts
+++ b/src/frontend/src/app/interceptors/technical.interceptor.ts
@@ -6,6 +6,7 @@ import { environment } from "../../environments/environment";
 import { catchError, finalize } from "rxjs/operators";
 import { MessageService } from "../services/message.service";
 import { LoaderService } from "../services/loader.service";
+import { SILENT_REQUEST } from "./http-context.tokens";
 
 @Injectable()
 export class TechnicalInterceptor implements HttpInterceptor {
@@ -20,6 +21,11 @@ export class TechnicalInterceptor implements HttpInterceptor {
     const requestToHandle = handleApogeeForbiddenLocally
       ? request.clone({headers: request.headers.delete('X-Handle-Apogee-Forbidden-Locally')})
       : request;
+    // Requête silencieuse (ex. ping keep-alive) : pas de loader, pas de blur,
+    // pas de popup d'erreur générique. L'appelant gère lui-même le résultat.
+    if (request.context.get(SILENT_REQUEST)) {
+      return next.handle(request);
+    }
     const inputs = ['input', 'select', 'button', 'textarea'];
     if (document.activeElement instanceof HTMLElement && inputs.indexOf(document.activeElement.tagName.toLowerCase()) > -1) {
       this.currentActiveElement = document.activeElement;

--- a/src/frontend/src/app/services/auth.service.ts
+++ b/src/frontend/src/app/services/auth.service.ts
@@ -1,15 +1,17 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from "@angular/common/http";
+import { HttpClient, HttpContext } from "@angular/common/http";
 import { environment } from "../../environments/environment";
 import {Observable, firstValueFrom, of, EMPTY} from "rxjs";
 import { catchError } from "rxjs/operators";
 import { TokenService } from "./token.service";
 import { Role } from "../constants/role";
+import { SILENT_REQUEST } from "../interceptors/http-context.tokens";
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
+
   userConnected: any = undefined;
   appVersion: any = undefined;
   private refreshPromise?: Promise<void>;
@@ -28,6 +30,27 @@ export class AuthService {
         return EMPTY;
       })
     );
+  }
+
+  /**
+   * Ping léger et silencieux d'un endpoint authentifié.
+   *
+   * Sert au keep-alive : l'appel rafraîchit le lastAccessedTime de la session
+   * HTTP côté serveur sans afficher de loader ni de popup d'erreur (voir
+   * {@link SILENT_REQUEST}). Ne met volontairement pas à jour userConnected.
+   */
+  pingSession(): Observable<any> {
+    return this.http.get(environment.apiUrl + "/users/connected", {
+      context: new HttpContext().set(SILENT_REQUEST, true),
+    });
+  }
+
+  /**
+   * Indique qu'une redirection CAS est déjà en cours (garde anti-boucle).
+   * S'appuie sur le marqueur posé par {@link handleUnauthorized} (valeur '1').
+   */
+  isCasRedirectInProgress(): boolean {
+    return sessionStorage.getItem(AuthService.CAS_REDIRECT_FLAG) === '1';
   }
 
   getAppVersion(): Observable<any> {

--- a/src/frontend/src/app/services/session-keep-alive.service.spec.ts
+++ b/src/frontend/src/app/services/session-keep-alive.service.spec.ts
@@ -1,0 +1,108 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { SessionKeepAliveService } from './session-keep-alive.service';
+import { AuthService } from './auth.service';
+import { MessageService } from './message.service';
+
+describe('SessionKeepAliveService', () => {
+  let service: SessionKeepAliveService;
+  let authService: jasmine.SpyObj<AuthService>;
+  let messageService: jasmine.SpyObj<MessageService>;
+
+  const INTERVAL = 1000;
+
+  beforeEach(() => {
+    authService = jasmine.createSpyObj('AuthService', ['pingSession', 'isCasRedirectInProgress']);
+    authService.pingSession.and.returnValue(of({}));
+    authService.isCasRedirectInProgress.and.returnValue(false);
+    messageService = jasmine.createSpyObj('MessageService', ['setWarning']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        SessionKeepAliveService,
+        { provide: AuthService, useValue: authService },
+        { provide: MessageService, useValue: messageService },
+      ],
+    });
+    service = TestBed.inject(SessionKeepAliveService);
+  });
+
+  afterEach(() => {
+    service.stop();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('pings while the user is active', fakeAsync(() => {
+    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
+    tick(INTERVAL);
+    expect(authService.pingSession).toHaveBeenCalledTimes(1);
+    service.stop();
+  }));
+
+  it('stops pinging once activity is older than the window (abandoned tab)', fakeAsync(() => {
+    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: INTERVAL });
+    tick(INTERVAL); // activité récente (entrée) -> 1 ping
+    tick(INTERVAL); // plus aucune activité depuis > fenêtre -> aucun ping
+    expect(authService.pingSession).toHaveBeenCalledTimes(1);
+    service.stop();
+  }));
+
+  it('keeps pinging as long as the user keeps interacting', fakeAsync(() => {
+    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: INTERVAL });
+    tick(INTERVAL);
+    window.dispatchEvent(new KeyboardEvent('keydown'));
+    tick(INTERVAL);
+    expect(authService.pingSession).toHaveBeenCalledTimes(2);
+    service.stop();
+  }));
+
+  it('is idempotent: a second start() does not create a second interval', fakeAsync(() => {
+    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
+    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
+    tick(INTERVAL);
+    expect(authService.pingSession).toHaveBeenCalledTimes(1);
+    service.stop();
+  }));
+
+  it('emits no ping after stop() (no leak)', fakeAsync(() => {
+    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
+    service.stop();
+    tick(3 * INTERVAL);
+    expect(authService.pingSession).not.toHaveBeenCalled();
+  }));
+
+  it('warns without clearing and stops on a 401 ping', fakeAsync(() => {
+    authService.pingSession.and.returnValue(throwError(() => ({ status: 401 })));
+    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
+    tick(INTERVAL);
+    expect(messageService.setWarning).toHaveBeenCalledTimes(1);
+    expect(service.isRunning()).toBeFalse();
+  }));
+
+  it('does not warn when a CAS redirect is already in progress', fakeAsync(() => {
+    authService.pingSession.and.returnValue(throwError(() => ({ status: 401 })));
+    authService.isCasRedirectInProgress.and.returnValue(true);
+    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
+    tick(INTERVAL);
+    expect(messageService.setWarning).not.toHaveBeenCalled();
+    service.stop();
+  }));
+
+  it('ignores transient network errors and retries on the next tick', fakeAsync(() => {
+    authService.pingSession.and.returnValues(
+      throwError(() => ({ status: 0 })),
+      of({}),
+    );
+    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
+    tick(INTERVAL); // erreur réseau transitoire -> pas de warning, on continue
+    tick(INTERVAL); // ping suivant OK
+    expect(messageService.setWarning).not.toHaveBeenCalled();
+    expect(authService.pingSession).toHaveBeenCalledTimes(2);
+    expect(service.isRunning()).toBeTrue();
+    service.stop();
+  }));
+});

--- a/src/frontend/src/app/services/session-keep-alive.service.spec.ts
+++ b/src/frontend/src/app/services/session-keep-alive.service.spec.ts
@@ -36,49 +36,53 @@ describe('SessionKeepAliveService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('pings while the user is active', fakeAsync(() => {
+  it('pings immediately on start (leading edge)', fakeAsync(() => {
+    service.start({ pingIntervalMs: INTERVAL });
+    expect(authService.pingSession).toHaveBeenCalledTimes(1);
+    service.stop();
+  }));
+
+  it('pings on each interval while the user is active', fakeAsync(() => {
     service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
+    authService.pingSession.calls.reset(); // on ignore le ping de démarrage
     tick(INTERVAL);
     expect(authService.pingSession).toHaveBeenCalledTimes(1);
-    service.stop();
-  }));
-
-  it('stops pinging once activity is older than the window (abandoned tab)', fakeAsync(() => {
-    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: INTERVAL });
-    tick(INTERVAL); // activité récente (entrée) -> 1 ping
-    tick(INTERVAL); // plus aucune activité depuis > fenêtre -> aucun ping
-    expect(authService.pingSession).toHaveBeenCalledTimes(1);
-    service.stop();
-  }));
-
-  it('keeps pinging as long as the user keeps interacting', fakeAsync(() => {
-    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: INTERVAL });
-    tick(INTERVAL);
     window.dispatchEvent(new KeyboardEvent('keydown'));
     tick(INTERVAL);
     expect(authService.pingSession).toHaveBeenCalledTimes(2);
     service.stop();
   }));
 
-  it('is idempotent: a second start() does not create a second interval', fakeAsync(() => {
-    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
-    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
-    tick(INTERVAL);
+  it('stops pinging once activity is older than the window (abandoned tab)', fakeAsync(() => {
+    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: INTERVAL });
+    authService.pingSession.calls.reset();
+    tick(INTERVAL); // activité (démarrage) encore dans la fenêtre -> 1 ping
+    tick(INTERVAL); // plus d'activité depuis > fenêtre -> aucun ping
     expect(authService.pingSession).toHaveBeenCalledTimes(1);
     service.stop();
   }));
 
   it('emits no ping after stop() (no leak)', fakeAsync(() => {
     service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
+    authService.pingSession.calls.reset();
     service.stop();
     tick(3 * INTERVAL);
     expect(authService.pingSession).not.toHaveBeenCalled();
   }));
 
+  it('is idempotent: a second start() does not create a second interval', fakeAsync(() => {
+    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
+    service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
+    // 1 ping de démarrage + 1 ping au tick = 2 (et pas 3, ce qui trahirait 2 timers)
+    tick(INTERVAL);
+    expect(authService.pingSession).toHaveBeenCalledTimes(2);
+    service.stop();
+  }));
+
   it('warns without clearing and stops on a 401 ping', fakeAsync(() => {
     authService.pingSession.and.returnValue(throwError(() => ({ status: 401 })));
     service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
-    tick(INTERVAL);
+    // le ping de démarrage suffit à déclencher la détection
     expect(messageService.setWarning).toHaveBeenCalledTimes(1);
     expect(service.isRunning()).toBeFalse();
   }));
@@ -87,21 +91,19 @@ describe('SessionKeepAliveService', () => {
     authService.pingSession.and.returnValue(throwError(() => ({ status: 401 })));
     authService.isCasRedirectInProgress.and.returnValue(true);
     service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
-    tick(INTERVAL);
     expect(messageService.setWarning).not.toHaveBeenCalled();
     service.stop();
   }));
 
-  it('ignores transient network errors and retries on the next tick', fakeAsync(() => {
-    authService.pingSession.and.returnValues(
-      throwError(() => ({ status: 0 })),
-      of({}),
+  it('ignores transient network errors and keeps running', fakeAsync(() => {
+    let call = 0;
+    authService.pingSession.and.callFake(() =>
+      call++ === 0 ? throwError(() => ({ status: 0 })) : of({}),
     );
     service.start({ pingIntervalMs: INTERVAL, activityWindowMs: 10 * INTERVAL });
-    tick(INTERVAL); // erreur réseau transitoire -> pas de warning, on continue
+    // ping de démarrage -> erreur réseau transitoire : pas de warning, on continue
     tick(INTERVAL); // ping suivant OK
     expect(messageService.setWarning).not.toHaveBeenCalled();
-    expect(authService.pingSession).toHaveBeenCalledTimes(2);
     expect(service.isRunning()).toBeTrue();
     service.stop();
   }));

--- a/src/frontend/src/app/services/session-keep-alive.service.ts
+++ b/src/frontend/src/app/services/session-keep-alive.service.ts
@@ -11,7 +11,8 @@ export interface KeepAliveOptions {
    *  du server.servlet.session.timeout. Défaut : 4 min. */
   pingIntervalMs?: number;
   /** Durée d'inactivité au-delà de laquelle on cesse de pinger (ms). Un onglet
-   *  abandonné laisse ainsi la session expirer. Défaut : identique à l'intervalle. */
+   *  abandonné laisse ainsi la session expirer. Doit être > pingIntervalMs pour
+   *  ne pas sauter de ping en régime actif. Défaut : 2 × l'intervalle. */
   activityWindowMs?: number;
 }
 
@@ -77,7 +78,11 @@ export class SessionKeepAliveService implements OnDestroy {
       return;
     }
     this.pingIntervalMs = options.pingIntervalMs ?? SessionKeepAliveService.DEFAULT_PING_INTERVAL_MS;
-    this.activityWindowMs = options.activityWindowMs ?? this.pingIntervalMs;
+    // Fenêtre d'activité DÉCOUPLÉE et plus large que l'intervalle : sinon, comme
+    // setInterval déclenche à "intervalle + ε", le calcul (now - lastActivity)
+    // dépasse la fenêtre et le ping est sauté juste au mauvais moment. On tolère
+    // par défaut 2 intervalles d'inactivité avant d'arrêter de pinger.
+    this.activityWindowMs = options.activityWindowMs ?? this.pingIntervalMs * 2;
     this.expiredNotified = false;
     // Entrer dans l'écran d'édition compte comme une activité.
     this.lastActivityAt = Date.now();
@@ -90,6 +95,10 @@ export class SessionKeepAliveService implements OnDestroy {
       });
       this.intervalId = setInterval(() => this.tick(), this.pingIntervalMs);
     });
+
+    // Ping immédiat (leading edge) : on rafraîchit la session dès l'entrée dans
+    // l'écran, sans attendre un intervalle entier (évite le trou de démarrage).
+    this.sendPing();
   }
 
   /**
@@ -111,6 +120,13 @@ export class SessionKeepAliveService implements OnDestroy {
   private tick(): void {
     // Pas d'activité récente : on laisse la session expirer (onglet abandonné).
     if (Date.now() - this.lastActivityAt > this.activityWindowMs) {
+      return;
+    }
+    this.sendPing();
+  }
+
+  private sendPing(): void {
+    if (this.expiredNotified) {
       return;
     }
     this.pingSub?.unsubscribe();

--- a/src/frontend/src/app/services/session-keep-alive.service.ts
+++ b/src/frontend/src/app/services/session-keep-alive.service.ts
@@ -1,0 +1,145 @@
+import { Injectable, NgZone, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { AuthService } from './auth.service';
+import { MessageService } from './message.service';
+
+/**
+ * Options de configuration d'une session de keep-alive.
+ */
+export interface KeepAliveOptions {
+  /** Intervalle entre deux tentatives de ping (ms). Doit rester bien en dessous
+   *  du server.servlet.session.timeout. Défaut : 4 min. */
+  pingIntervalMs?: number;
+  /** Durée d'inactivité au-delà de laquelle on cesse de pinger (ms). Un onglet
+   *  abandonné laisse ainsi la session expirer. Défaut : identique à l'intervalle. */
+  activityWindowMs?: number;
+}
+
+/**
+ * Maintient vivante la session HTTP côté serveur pendant qu'un écran d'édition
+ * longue (CKEditor, etc.) est ouvert ET que l'utilisateur est réellement actif.
+ *
+ * Problème résolu : pendant la rédaction, aucune requête n'est émise ; si la
+ * durée dépasse le timeout de session, le « Valider » final renvoie un 401 et le
+ * travail est perdu. Le keep-alive pingue périodiquement un endpoint authentifié
+ * léger (GET /api/users/connected) pour rafraîchir le lastAccessedTime.
+ *
+ * Le ping n'est émis que si l'utilisateur a interagi récemment (clavier, souris,
+ * molette, tactile) : un onglet laissé à l'abandon cesse d'être pingé et la
+ * session finit par expirer normalement (le logout d'inactivité est préservé).
+ *
+ * Réutilisable : injecter le service, appeler {@link start} en entrant dans
+ * l'écran d'édition et {@link stop} en le quittant (ngOnDestroy, changement
+ * d'onglet, etc.).
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class SessionKeepAliveService implements OnDestroy {
+
+  private static readonly DEFAULT_PING_INTERVAL_MS = 4 * 60 * 1000;
+
+  /** Évènements DOM considérés comme une activité utilisateur réelle.
+   *  La saisie dans CKEditor remonte jusqu'au document via keydown. */
+  private static readonly ACTIVITY_EVENTS = ['keydown', 'mousedown', 'mousemove', 'wheel', 'touchstart'];
+
+  private intervalId: any = null;
+  private pingSub?: Subscription;
+  private lastActivityAt = 0;
+  private pingIntervalMs = SessionKeepAliveService.DEFAULT_PING_INTERVAL_MS;
+  private activityWindowMs = SessionKeepAliveService.DEFAULT_PING_INTERVAL_MS;
+  private expiredNotified = false;
+
+  private readonly activityListener = (): void => {
+    this.lastActivityAt = Date.now();
+  };
+
+  constructor(
+    private authService: AuthService,
+    private messageService: MessageService,
+    private ngZone: NgZone,
+  ) { }
+
+  ngOnDestroy(): void {
+    this.stop();
+  }
+
+  isRunning(): boolean {
+    return this.intervalId !== null;
+  }
+
+  /**
+   * Démarre le keep-alive. Idempotent : un appel alors que le service tourne
+   * déjà est ignoré.
+   */
+  start(options: KeepAliveOptions = {}): void {
+    if (this.isRunning()) {
+      return;
+    }
+    this.pingIntervalMs = options.pingIntervalMs ?? SessionKeepAliveService.DEFAULT_PING_INTERVAL_MS;
+    this.activityWindowMs = options.activityWindowMs ?? this.pingIntervalMs;
+    this.expiredNotified = false;
+    // Entrer dans l'écran d'édition compte comme une activité.
+    this.lastActivityAt = Date.now();
+
+    // Hors zone Angular : les évènements de souris/clavier et le timer ne doivent
+    // pas déclencher de détection de changement à chaque frappe/déplacement.
+    this.ngZone.runOutsideAngular(() => {
+      SessionKeepAliveService.ACTIVITY_EVENTS.forEach(event => {
+        window.addEventListener(event, this.activityListener, { passive: true });
+      });
+      this.intervalId = setInterval(() => this.tick(), this.pingIntervalMs);
+    });
+  }
+
+  /**
+   * Arrête le keep-alive et nettoie timer, écouteurs et souscription en cours.
+   * Sûr à appeler même si le service n'a jamais démarré (idempotent).
+   */
+  stop(): void {
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    SessionKeepAliveService.ACTIVITY_EVENTS.forEach(event => {
+      window.removeEventListener(event, this.activityListener);
+    });
+    this.pingSub?.unsubscribe();
+    this.pingSub = undefined;
+  }
+
+  private tick(): void {
+    // Pas d'activité récente : on laisse la session expirer (onglet abandonné).
+    if (Date.now() - this.lastActivityAt > this.activityWindowMs) {
+      return;
+    }
+    this.pingSub?.unsubscribe();
+    this.pingSub = this.authService.pingSession().subscribe({
+      error: (err: any) => this.handlePingError(err),
+    });
+  }
+
+  private handlePingError(err: any): void {
+    // Erreur réseau transitoire : on réessaiera au prochain tick.
+    if (err?.status !== 401 && err?.status !== 403) {
+      return;
+    }
+    // Une redirection CAS est déjà gérée ailleurs : ne pas interférer.
+    if (this.authService.isCasRedirectInProgress()) {
+      return;
+    }
+    if (this.expiredNotified) {
+      return;
+    }
+    this.expiredNotified = true;
+    // Session expirée côté serveur : inutile de continuer à pinger. On prévient
+    // l'utilisateur SANS vider l'éditeur, pour qu'il puisse se reconnecter et
+    // sauvegarder son travail.
+    this.stop();
+    this.ngZone.run(() => {
+      this.messageService.setWarning(
+        'Votre session a expiré. Reconnectez-vous (dans un autre onglet) avant de réessayer d’enregistrer : votre travail en cours n’a pas été perdu.'
+      );
+    });
+  }
+}


### PR DESCRIPTION
Envoi régulier de requêtes au backend afin de maintenir la session active lors de la création ou de la modification d'un template de convention.