### PR TITLE
fix: un seul scroll page et footer stabilisé sur les tableaux

### DIFF
--- a/src/frontend/src/app/app.component.scss
+++ b/src/frontend/src/app/app.component.scss
@@ -1,14 +1,29 @@
 @import "@fortawesome/fontawesome-free/css/all.css";
 
-/* Conteneur principal */
+/* Colonne pleine hauteur pour coller le footer en bas quand le contenu est court */
+:host {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/*
+ * Un seul scroll vertical (la page) : le sidenav Material ne doit pas créer
+ * un overflow interne (sinon footer décalé + doubles/triples barres).
+ */
 mat-sidenav-container {
-  min-height: calc(100vh - 64px);
+  flex: 1 0 auto;
+  overflow: visible !important;
 }
 
 mat-sidenav-content {
-  padding: 30px 10px 0px 10px;
-  overflow-y: auto;
-  overflow-x: hidden;
+  padding: 30px 10px 0;
+  height: auto !important;
+  overflow: visible !important;
+}
+
+app-footer {
+  flex: 0 0 auto;
 }
 
 .app-menu {
@@ -130,9 +145,4 @@ mat-sidenav-content {
 .maintenance-announcement__close:focus-visible {
   text-decoration: underline;
   outline: none;
-}
-
-.mat-sidenav-content{
-  overflow-y: hidden;
-  margin-bottom : 20px;
 }

--- a/src/frontend/src/app/components/table/table.component.scss
+++ b/src/frontend/src/app/components/table/table.component.scss
@@ -12,14 +12,15 @@
 
 
 .app-table {
+  /* Scroll horizontal seulement — pas de max-height pour éviter un 2e scroll vertical */
   overflow-x: auto;
-  max-height: 650px;
-  display: block; /* Ajout pour forcer le conteneur à être un bloc */
+  overflow-y: visible;
+  display: block;
 
   .mat-table {
-    width: 100%; /* Force le tableau à occuper 100% de la largeur disponible */
-    table-layout: auto; /* Permet une répartition automatique des colonnes */
-    word-wrap: break-word; /* Gère les longues chaînes sans débordement */
+    width: 100%;
+    table-layout: auto;
+    word-wrap: break-word;
   }
 }
 


### PR DESCRIPTION
## Summary
- Supprime le scroll interne du sidenav Material et le `max-height` du tableau
- Un seul scroll vertical (page) ; footer collé en bas si le contenu est court

## Test plan
- [ ] Tableau-de-bord : une seule barre de scroll
- [ ] Footer visible en bas, non décalé
- [ ] Autres listes avec `app-table` OK (scroll horizontal conservé)
