### PR TITLE
story #8970 - amélioration gestion de la fin de session

### DIFF
--- a/src/frontend/src/app/components/message/message.component.scss
+++ b/src/frontend/src/app/components/message/message.component.scss
@@ -33,6 +33,6 @@ h1 {
 
 .message-ok-button{
   background-color: var(--primaryColor);
-  color: white ;
+  color: white !important;
   font-weight: 500;
 }

--- a/src/frontend/src/app/interceptors/technical.interceptor.ts
+++ b/src/frontend/src/app/interceptors/technical.interceptor.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Injector } from '@angular/core';
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Observable, ObservableInput } from 'rxjs';
 import { TokenService } from "../services/token.service";
@@ -6,14 +6,24 @@ import { environment } from "../../environments/environment";
 import { catchError, finalize } from "rxjs/operators";
 import { MessageService } from "../services/message.service";
 import { LoaderService } from "../services/loader.service";
+import { AuthService } from "../services/auth.service";
 
 @Injectable()
 export class TechnicalInterceptor implements HttpInterceptor {
 
   private nbRequests: number = 0;
   private currentActiveElement :any;
+  private unauthenticatedHandled: boolean = false;
 
-  constructor(private tokenService: TokenService, private messageService: MessageService, private loaderService: LoaderService) {}
+  constructor(private tokenService: TokenService, private messageService: MessageService, private loaderService: LoaderService, private injector: Injector) {
+    // Voir AuthService : au retour depuis le bfcache, le drapeau doit repartir de zéro, sinon
+    // plus aucune fenêtre ne serait affichée sur les 401 suivants.
+    window.addEventListener('pageshow', (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        this.unauthenticatedHandled = false;
+      }
+    });
+  }
 
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     const handleApogeeForbiddenLocally = request.headers.has('X-Handle-Apogee-Forbidden-Locally');
@@ -55,12 +65,7 @@ export class TechnicalInterceptor implements HttpInterceptor {
       throw error;
     }
     if (error?.status === 401) {
-      const authReason = error?.headers?.get?.("X-Auth-Reason");
-      if (authReason === "idle") {
-        this.messageService.setWarning("Vous avez été déconnecté suite à une période d'inactivité prolongée");
-      } else {
-        this.messageService.setWarning("Session non authentifiée. Merci de vous reconnecter.");
-      }
+      this.handleUnauthenticated(error);
       throw error;
     }
     if (error.error instanceof Blob) {
@@ -93,6 +98,40 @@ export class TechnicalInterceptor implements HttpInterceptor {
       }
     }
     throw error;
+  }
+
+  /**
+   * Une session expirée fait généralement échouer plusieurs requêtes en parallèle : on n'affiche
+   * la fenêtre qu'une seule fois, et sa fermeture (OK, Échap ou clic hors de la fenêtre) renvoie
+   * vers la page de connexion plutôt que de laisser l'utilisateur sur un écran inutilisable.
+   */
+  private handleUnauthenticated(error: any): void {
+    if (this.unauthenticatedHandled) {
+      return;
+    }
+    this.unauthenticatedHandled = true;
+    const authService = this.injector.get(AuthService);
+    authService.markSessionDialogPending();
+    const authReason = error?.headers?.get?.("X-Auth-Reason");
+    this.messageService.setWarning(this.getUnauthenticatedMessage(authReason), true, () => {
+      authService.reconnect();
+    });
+  }
+
+  private getUnauthenticatedMessage(authReason: string | null | undefined): string {
+    switch (authReason) {
+      case "idle":
+        return "<strong>Votre session a expiré.</strong><br>"
+          + "Par mesure de sécurité, vous avez été déconnecté après une période d'inactivité prolongée.<br>"
+          + "Cliquez sur OK pour revenir à la page de connexion.";
+      case "admin-logout":
+        return "<strong>Votre session a été fermée.</strong><br>"
+          + "Une nouvelle connexion à votre compte a été détectée, ou un administrateur a mis fin à votre session.<br>"
+          + "Cliquez sur OK pour revenir à la page de connexion.";
+      default:
+        return "<strong>Vous n'êtes plus authentifié.</strong><br>"
+          + "Cliquez sur OK pour revenir à la page de connexion.";
+    }
   }
 
   private isApogeeStudentForbiddenError(error: any, request?: HttpRequest<unknown>): boolean {

--- a/src/frontend/src/app/services/auth.service.ts
+++ b/src/frontend/src/app/services/auth.service.ts
@@ -14,17 +14,28 @@ export class AuthService {
   appVersion: any = undefined;
   private refreshPromise?: Promise<void>;
   private redirecting = false;
+  private sessionDialogPending = false;
 
   private adminTechList: string[] = [];
   private adminTechLoaded = false;
   private adminTechLoadingPromise?: Promise<void>;
 
-  constructor(private http: HttpClient, private tokenService: TokenService) { }
+  constructor(private http: HttpClient, private tokenService: TokenService) {
+    // Restauration depuis le bfcache : le navigateur rend le tas JS tel qu'il était, drapeaux
+    // compris. Sans cette remise à zéro, la page reviendrait en paraissant connectée alors que
+    // la session est morte, sans plus jamais pouvoir rediriger.
+    window.addEventListener('pageshow', (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        this.redirecting = false;
+        this.sessionDialogPending = false;
+      }
+    });
+  }
 
   getCurrentUser(): Observable<any> {
     return this.http.get(environment.apiUrl + "/users/connected").pipe(
       catchError(() => {
-        this.handleUnauthorized();
+        this.redirectToLogin();
         return EMPTY;
       })
     );
@@ -40,7 +51,7 @@ export class AuthService {
     return this.http.get<string[]>(environment.apiUrl + "/users/admintech").pipe(
       catchError((error) => {
         if (error?.status === 401 || error?.status === 403) {
-          this.handleUnauthorized();
+          this.redirectToLogin();
         }
         return of([]);
       })
@@ -55,14 +66,44 @@ export class AuthService {
     return new URL(url, window.location.href).toString();
   }
 
-  private handleUnauthorized() {
+  /**
+   * Signale qu'une fenêtre « session expirée » est ouverte. Tant qu'elle l'est, les redirections
+   * silencieuses déclenchées par les appels en échec sont suspendues : sans ça l'utilisateur est
+   * renvoyé vers le CAS avant même d'avoir pu lire le message.
+   */
+  markSessionDialogPending(): void {
+    this.sessionDialogPending = true;
+  }
+
+  redirectToLogin() {
+    if (this.sessionDialogPending) {
+      return;
+    }
+    this.navigateToLogin(false);
+  }
+
+  /**
+   * Reconnexion demandée par l'utilisateur depuis la fenêtre de session expirée.
+   * Le paramètre renew=1 est relu par le back (SecurityConfiguration#casEntryPoint), qui envoie
+   * alors renew=true au CAS. Sans lui, le CAS réutilise sa propre session SSO, réauthentifie
+   * l'utilisateur sans rien lui demander et le dépose sur l'accueil.
+   */
+  reconnect(): void {
+    this.sessionDialogPending = false;
+    this.navigateToLogin(true);
+  }
+
+  private navigateToLogin(renew: boolean) {
     if (!this.redirecting) {
       this.redirecting = true;
       const currentPath = window.location.pathname;
       const loginPath = this.resolvePath(environment.loginUrl);
       if (currentPath !== loginPath) {
         sessionStorage.setItem('redirectUrl', currentPath);
-        window.location.href = this.resolveUrl(environment.loginUrl);
+        const loginUrl = renew ? environment.loginUrl + '?renew=1' : environment.loginUrl;
+        // replace() plutôt que href= : la page expirée n'est pas empilée dans l'historique, un
+        // retour arrière depuis le CAS ne peut donc plus y ramener.
+        window.location.replace(this.resolveUrl(loginUrl));
       }
     }
   }

--- a/src/frontend/src/app/services/message.service.ts
+++ b/src/frontend/src/app/services/message.service.ts
@@ -15,7 +15,7 @@ export class MessageService {
 
   constructor(private dialog: MatDialog) { }
 
-  setMessage(message: string, type: string, keep: boolean = true) {
+  setMessage(message: string, type: string, keep: boolean = true, onClose?: () => void) {
     this.type = type;
     switch (this.type) {
       case 'error':
@@ -35,7 +35,7 @@ export class MessageService {
     if (!keep) {
       setTimeout(() => this.close(), 1000 );
     }
-    this.open();
+    this.open(onClose);
   }
 
   setError(message: string, keep: boolean = true): void {
@@ -46,8 +46,8 @@ export class MessageService {
     this.setMessage(message, 'success', keep);
   }
 
-  setWarning(message: string, keep: boolean = true): void {
-    this.setMessage(message, 'warning', keep);
+  setWarning(message: string, keep: boolean = true, onClose?: () => void): void {
+    this.setMessage(message, 'warning', keep, onClose);
   }
 
   setAccessDenied(message: string, keep: boolean = true): void {
@@ -66,8 +66,11 @@ export class MessageService {
     return this.message;
   }
 
-  open(): void {
+  open(onClose?: () => void): void {
     this.dialogRef = this.dialog.open(MessageComponent, { minWidth: '30%' });
+    if (onClose) {
+      this.dialogRef.afterClosed().subscribe(() => onClose());
+    }
   }
 
   close(): void {


### PR DESCRIPTION
- Libellés du 401 réécrits, avec un message distinct par X-Auth-Reason (idle, admin-logout, défaut).
- Une seule fenêtre par expiration, au lieu d'une par requête échouée — c'est ce qui provoquait l'erreur après plusieurs clics sur OK.
- À la fermeture, redirection vers /login/cas?renew=1 : sans renew, le CAS réauthentifiait en silence et renvoyait sur l'accueil.
- Deux effets de bord corrigés : les redirections silencieuses de AuthService ne partent plus avant que le message soit lu, et location.replace() empêche le retour arrière de ramener sur l'écran expiré.