### PR TITLE
issue #700 - correction création nomenclatures

### DIFF
--- a/src/main/java/org/esup_portail/esup_stage/repository/PaginationRepository.java
+++ b/src/main/java/org/esup_portail/esup_stage/repository/PaginationRepository.java
@@ -274,7 +274,7 @@ public class PaginationRepository<T extends Exportable> {
         TypedQuery<Integer> query = em.createQuery(queryString, Integer.class);
         query.setParameter("libelle", libelle);
         List<Integer> results = query.getResultList();
-        if (id == 0 && results.isEmpty()) {
+        if (id == 0 && results.size() > 0) {
             return true;
         }
 

--- a/src/main/java/org/esup_portail/esup_stage/repository/TypeConventionRepository.java
+++ b/src/main/java/org/esup_portail/esup_stage/repository/TypeConventionRepository.java
@@ -23,7 +23,7 @@ public class TypeConventionRepository extends PaginationRepository<TypeConventio
         TypedQuery<Integer> query = em.createQuery(queryString, Integer.class);
         query.setParameter("codeCtrl", codeCtrl);
         List<Integer> results = query.getResultList();
-        if (id == 0 && results.isEmpty()) {
+        if (id == 0 && results.size() > 0) {
             return true;
         }
 


### PR DESCRIPTION
## Description / Objectif / Motivation / Contexte

Correction d'une régression en v3.2.4+ : la méthode exists() retournait true à la création
quand le libellé/code n'existait pas encore, bloquant toute création de nomenclature via l'application.

Ticket / Issue : #700

## Type de changement

- [x] Correction de bug

## Test plan

- [ ] Créer une nomenclature par libellé (ex. Thème) avec un libellé inexistant → succès
- [ ] Créer une nomenclature avec un libellé déjà existant → erreur « Libellé déjà existant »
- [ ] Créer un Type Convention avec un code inexistant → succès