### PR TITLE
Story #9030 - traduction anglaise par défaut des libellés d'impression

### DIFF
--- a/src/main/resources/i18n/impression_en.properties
+++ b/src/main/resources/i18n/impression_en.properties
@@ -1,64 +1,64 @@
 # Libelles inseres automatiquement par l'application dans les documents imprimes - anglais (en).
 #
-# Les valeurs sont volontairement vides : une cle vide est remplacee par la valeur
-# francaise du fichier impression_fr.properties. Renseignez uniquement les lignes
-# que vous souhaitez traduire, la traduction partielle est prise en charge.
+# Traduction anglaise livree par defaut avec l'application.
+# Une cle vide est remplacee par la valeur francaise du fichier impression_fr.properties.
+# Renseignez uniquement les lignes que vous souhaitez traduire, la traduction partielle est prise en charge.
 #
 # Encodage : UTF-8 obligatoire.
 # Ces libelles ont une portee juridique : faites valider les traductions.
 # Documentation : Traduction des libelles d'impression.
 
 # Libelles reutilises dans plusieurs blocs
-commun.debut=
-commun.fin=
-commun.neant=
-commun.anciennesValeurs=
-commun.nouvellesValeurs=
-commun.du=
-commun.au=
+commun.debut=Start
+commun.fin=End
+commun.neant=None
+commun.anciennesValeurs=Previous values:
+commun.nouvellesValeurs=New values:
+commun.du=From
+commun.au=To
 
 # Intitules de champs, suivis de leur valeur
-champ.nom=
-champ.prenom=
-champ.nomPrenom=
-champ.civilite=
-champ.fonction=
-champ.telephone=
-champ.email=
-champ.voie=
-champ.codePostal=
-champ.commune=
-champ.pays=
-champ.sujet=
-champ.commentaire=
-champ.motif=
-champ.dateRupture=
-champ.dateDebutStage=
-champ.dateFinStage=
-champ.periodesInterruptions=
-champ.montant=
-champ.devise=
-champ.modeVersement=
+champ.nom=Last name
+champ.prenom=First name
+champ.nomPrenom=Last name First name:
+champ.civilite=Title:
+champ.fonction=Position:
+champ.telephone=Phone:
+champ.email=Email:
+champ.voie=Street:
+champ.codePostal=Postal code:
+champ.commune=City:
+champ.pays=Country:
+champ.sujet=Subject:
+champ.commentaire=Comment:
+champ.motif=Reason:
+champ.dateRupture=Termination date:
+champ.dateDebutStage=Internship start date:
+champ.dateFinStage=Internship end date:
+champ.periodesInterruptions=Interruption periods:
+champ.montant=Amount:
+champ.devise=Currency used for payment:
+champ.modeVersement=Internship allowance payment method:
 
 # Convention - article 6.3, protection sociale issue de l'organisme d'accueil
-protectionSociale.oui.libelle=
-protectionSociale.oui.texte=
-protectionSociale.non.libelle=
-protectionSociale.non.texte=
+protectionSociale.oui.libelle=YES
+protectionSociale.oui.texte=this protection is in addition to the continued entitlement, abroad, to rights under French law.
+protectionSociale.non.libelle=NO
+protectionSociale.non.texte=the protection then derives exclusively from the continued entitlement, abroad, to rights under the French student social security scheme.
 
 # Convention - tableau des periodes d'interruption de stage
-periodesInterruptions.titre=
+periodesInterruptions.titre=Internship interruption periods
 
 # Convention - tableau des periodes de stage a horaires irreguliers
-horaireIrregulier.titre=
-horaireIrregulier.heuresJournalieres=
+horaireIrregulier.titre=Internship periods
+horaireIrregulier.heuresJournalieres=Daily hours:
 
 # Avenant - intitules des motifs de modification
-avenant.rupture.titre=
-avenant.sujet.titre=
-avenant.periode.titre=
-avenant.gratification.titre=
-avenant.lieu.titre=
-avenant.tuteur.titre=
-avenant.enseignant.titre=
-avenant.autre.titre=
+avenant.rupture.titre=Internship termination
+avenant.sujet.titre=Change to the internship subject
+avenant.periode.titre=Change to the internship period
+avenant.gratification.titre=Change to the internship allowance amount
+avenant.lieu.titre=Change to the internship location
+avenant.tuteur.titre=Change to the professional supervisor
+avenant.enseignant.titre=Change to the academic supervisor
+avenant.autre.titre=Other change

--- a/src/test/java/org/esup_portail/esup_stage/controller/AppConfigControllerLibellesImpressionTest.java
+++ b/src/test/java/org/esup_portail/esup_stage/controller/AppConfigControllerLibellesImpressionTest.java
@@ -80,7 +80,7 @@ class AppConfigControllerLibellesImpressionTest {
         LibelleImpressionLangueDto francais = langues.get(0);
         assertThat(francais.getNbClesRenseignees()).isEqualTo(francais.getNbClesTotal()).isPositive();
         assertThat(francais.isSurcharge()).isFalse();
-        assertThat(langues.get(1).getNbClesRenseignees()).isZero();
+        assertThat(langues.get(1).getNbClesRenseignees()).isEqualTo(langues.get(1).getNbClesTotal()).isPositive();
     }
 
     @Test
@@ -90,7 +90,7 @@ class AppConfigControllerLibellesImpressionTest {
         LibelleImpressionLangueDto anglais = controller.getLibellesImpression().get(1);
         assertThat(anglais.isSurcharge()).isTrue();
         assertThat(anglais.getDateModification()).isNotNull();
-        assertThat(anglais.getNbClesRenseignees()).isEqualTo(1);
+        assertThat(anglais.getNbClesRenseignees()).isEqualTo(anglais.getNbClesTotal()).isPositive();
     }
 
     @Test
@@ -104,11 +104,11 @@ class AppConfigControllerLibellesImpressionTest {
 
     @Test
     void leDepotEstPrisEnCompteImmediatement() {
-        assertThat(libelleImpressionService.getLibelles("en").get(CLE_OUI)).isEqualTo("OUI");
-
-        controller.updateLibellesImpression("en", fichier("impression_en.properties", CLE_OUI + "=YES\n"));
-
         assertThat(libelleImpressionService.getLibelles("en").get(CLE_OUI)).isEqualTo("YES");
+
+        controller.updateLibellesImpression("en", fichier("impression_en.properties", CLE_OUI + "=CUSTOM\n"));
+
+        assertThat(libelleImpressionService.getLibelles("en").get(CLE_OUI)).isEqualTo("CUSTOM");
     }
 
     @Test
@@ -130,12 +130,12 @@ class AppConfigControllerLibellesImpressionTest {
 
     @Test
     void laSuppressionRetablitLeComportementLivre() {
-        controller.updateLibellesImpression("en", fichier("impression_en.properties", CLE_OUI + "=YES\n"));
+        controller.updateLibellesImpression("en", fichier("impression_en.properties", CLE_OUI + "=CUSTOM\n"));
 
         controller.deleteLibellesImpression("en");
 
         assertThat(cheminSurcharge("en")).doesNotExist();
-        assertThat(libelleImpressionService.getLibelles("en").get(CLE_OUI)).isEqualTo("OUI");
+        assertThat(libelleImpressionService.getLibelles("en").get(CLE_OUI)).isEqualTo("YES");
     }
 
     @Test

--- a/src/test/java/org/esup_portail/esup_stage/service/impression/LibelleImpressionServiceTest.java
+++ b/src/test/java/org/esup_portail/esup_stage/service/impression/LibelleImpressionServiceTest.java
@@ -53,9 +53,14 @@ class LibelleImpressionServiceTest {
     }
 
     @Test
+    void sertLesLibellesAnglaisLivresParDefaut() {
+        assertThat(service.getLibelles("en").get(CLE_OUI)).isEqualTo("YES");
+        assertThat(service.getLibelles("en").get("commun.debut")).isEqualTo("Start");
+    }
+
+    @Test
     void replieSurLeFrancaisQuandLaLangueLivreeNestPasTraduite() {
-        // les fichiers livrés pour les langues étrangères sont volontairement vides
-        assertThat(service.getLibelles("en")).isEqualTo(service.getLibelles("fr"));
+        assertThat(service.getLibelles("it")).isEqualTo(service.getLibelles("fr"));
     }
 
     @Test
@@ -87,7 +92,7 @@ class LibelleImpressionServiceTest {
 
         Map<String, String> libelles = service.getLibelles("en");
         assertThat(libelles.get(CLE_OUI)).isEqualTo("YES");
-        assertThat(libelles.get(CLE_TEXTE)).isEqualTo("cette protection s'ajoute au maintien, à l'étranger, des droits issus du droit français.");
+        assertThat(libelles.get(CLE_TEXTE)).isEqualTo("this protection is in addition to the continued entitlement, abroad, to rights under French law.");
         assertThat(libelles.keySet()).isEqualTo(service.getClesAutorisees());
     }
 
@@ -128,11 +133,12 @@ class LibelleImpressionServiceTest {
     void compteLesLibellesEffectivementTraduits() {
         int total = service.getClesAutorisees().size();
         assertThat(service.compterClesTraduites("fr")).isEqualTo(total);
-        assertThat(service.compterClesTraduites("en")).isZero();
+        assertThat(service.compterClesTraduites("en")).isEqualTo(total);
+        assertThat(service.compterClesTraduites("it")).isZero();
 
-        service.ecrireSurcharge("en", (CLE_OUI + "=YES\n" + CLE_TEXTE + "=\n").getBytes(StandardCharsets.UTF_8));
+        service.ecrireSurcharge("it", (CLE_OUI + "=SI\n" + CLE_TEXTE + "=\n").getBytes(StandardCharsets.UTF_8));
 
-        assertThat(service.compterClesTraduites("en")).isEqualTo(1);
+        assertThat(service.compterClesTraduites("it")).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
Établissement / Personne déposant la PR : EsupPortail

## Description / Objectif / Motivation / Contexte

Suite à l'ajout de l'onglet **Langues** dans les paramètres généraux (story #9030), le fichier `impression_en.properties` livré avec l'application était volontairement vide : les libellés anglais retombaient alors sur le français.

Cette PR renseigne la traduction anglaise par défaut de l'ensemble des clés d'impression, afin que les conventions en anglais affichent directement les libellés traduits sans surcharge établissement.

Les établissements conservent la possibilité de déposer une surcharge via l'onglet Langues.

Ticket / Issue : #9030

## Checklist de PR

- [x] Ma PR pointe vers la branche `dev`
- [ ] Ma PR suit les différentes étapes du [guide de contribution](https://www.esup-portail.org/wiki/x/KQCeUQ)
- [x] Les modifications ont été testées de mon côté
- [ ] La documentation a été mise à jour si nécessaire (README, Wiki Esup)
- [x] Mes commits suivent la convention du projet et l'historique est propre
- [x] J'ai vérifié l'absence de conflits avec la branche cible

## Type de changement

- [ ] 🐛 Correction de bug
- [x] ✨ Nouvelle fonctionnalité
- [ ] 💥 Changement cassant
- [ ] 📝 Mise à jour de la documentation
- [x] ✅ Ajout / mise à jour de tests

## Comportement actuel

Le fichier `impression_en.properties` livré est vide : l'anglais repose entièrement sur le repli français. L'onglet Langues affiche 0 clé renseignée pour l'anglais.

## Nouveau comportement

Le fichier `impression_en.properties` contient la traduction anglaise par défaut de toutes les clés. L'onglet Langues affiche l'anglais comme entièrement traduit. Une surcharge établissement reste possible et prioritaire.

## Cas d'acceptance (Comment cela a-t-il été testé ?)

- [x] **Test A** — Étant donné une convention en anglais, quand le PDF est généré, alors les libellés automatiques (article 6.3, champs, avenants, tableaux) sont en anglais.
- [x] **Test B** — Étant donné l'onglet Langues des paramètres généraux, quand on consulte l'anglais, alors toutes les clés apparaissent renseignées sans fichier déposé.
- [x] **Tests unitaires** — `LibelleImpressionServiceTest`, `AppConfigControllerLibellesImpressionTest`, `FragmentsImpressionLibellesTest` (35 tests OK).

## Changement cassant (*Breaking Change*) ?

- [x] Non
- [ ] Oui

## Définition du fini

- [x] Les cas d'acceptance ci-dessus ont été vérifiés
- [ ] Revue par au moins un⋅e relecteur⋅ice autorisé⋅e
- [ ] Documentation(s) mise(s) à jour si nécessaire
- [ ] Si des changements *cassants* sont introduits, ils sont dûment décrits

## Information complémentaire

Complète la PR #679 (story #9030). Les autres langues livrées (`es`, `al`, `it`, `fo`) restent vides et continuent de se replier sur le français clé par clé.