### PR TITLE
Release v3.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<description>Application ESUP-Stage</description>
 
 	<properties>
-		<revision>3.2.5</revision>
+		<revision>3.2.6</revision>
 		<sha1></sha1>
 		<changelist></changelist>
 

--- a/src/main/java/org/esup_portail/esup_stage/repository/PaginationRepository.java
+++ b/src/main/java/org/esup_portail/esup_stage/repository/PaginationRepository.java
@@ -274,7 +274,7 @@ public class PaginationRepository<T extends Exportable> {
         TypedQuery<Integer> query = em.createQuery(queryString, Integer.class);
         query.setParameter("libelle", libelle);
         List<Integer> results = query.getResultList();
-        if (id == 0 && results.isEmpty()) {
+        if (id == 0 && results.size() > 0) {
             return true;
         }
 

--- a/src/main/java/org/esup_portail/esup_stage/repository/TypeConventionRepository.java
+++ b/src/main/java/org/esup_portail/esup_stage/repository/TypeConventionRepository.java
@@ -23,7 +23,7 @@ public class TypeConventionRepository extends PaginationRepository<TypeConventio
         TypedQuery<Integer> query = em.createQuery(queryString, Integer.class);
         query.setParameter("codeCtrl", codeCtrl);
         List<Integer> results = query.getResultList();
-        if (id == 0 && results.isEmpty()) {
+        if (id == 0 && results.size() > 0) {
             return true;
         }
 


### PR DESCRIPTION
Passage de la version 3.2.5 à 3.2.6.

## Corrections

- **#703** — issue #700 : correction de la création de nomenclatures. La vérification d'unicité (`exists()`) retournait à tort un doublon lors de la création d'un libellé ou d'un code inexistant, bloquant toute création via l'application.
  `PaginationRepository`, `TypeConventionRepository`

## Test plan

- [ ] Créer une nomenclature par libellé (ex. Thème) avec un libellé inexistant → succès
- [ ] Créer une nomenclature avec un libellé déjà existant → erreur « Libellé déjà existant »
- [ ] Créer un Type Convention avec un code inexistant → succès
- [ ] Vérifier la version affichée : 3.2.6