### PR TITLE
Afficher l'intitulé de formation sur l'onglet Étudiant (#112)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,7 @@ https://github.com/EsupPortail/esup-stage/releases/tag/3.2.4[Esup-Stage v3.2.4]
 
 === Améliorations
 - Permettre d'associer de 1 à n régimes d'inscription par type de convention.
+- Afficher l'intitulé de la formation sur l'onglet Étudiant, sur une ligne avec infobulle (#112).
 - Possibilité pour un admin de supprimer un établissement d'accueil via un bouton (#256).
 - Demander à l’étudiant de répondre au choix proposé par l’article 6.3.
 - Installation de l’application dans une webapp spécifique.

--- a/src/frontend/src/app/components/convention-create-en-masse/cadre-stage/cadre-stage-modal/cadre-stage-modal.component.html
+++ b/src/frontend/src/app/components/convention-create-en-masse/cadre-stage/cadre-stage-modal/cadre-stage-modal.component.html
@@ -133,7 +133,14 @@
                         </div>
                         <div class="row mb-2">
                           <div class="col-sm-4 font-weight-bold">Formation</div>
-                          <div class="col-sm-8">{{selectedInscription.etapeInscription.codeEtp}}{{selectedInscription.etapeInscription.libComposante != null ? ' - ' + selectedInscription.etapeInscription.libComposante : ''}}</div>
+                          <div class="col-sm-8 formation-display">
+                            <span
+                              class="formation-label"
+                              [matTooltip]="getFormationTooltip(selectedInscription)"
+                              matTooltipShowDelay="300">
+                              {{ getFormationDisplayLabel(selectedInscription) }}
+                            </span>
+                          </div>
                         </div>
                         @if (selectedInscription.elementPedagogiques.length > 0) {
                           <div class="row">

--- a/src/frontend/src/app/components/convention-create-en-masse/cadre-stage/cadre-stage-modal/cadre-stage-modal.component.scss
+++ b/src/frontend/src/app/components/convention-create-en-masse/cadre-stage/cadre-stage-modal/cadre-stage-modal.component.scss
@@ -3,6 +3,18 @@
   font-size: 12px;
 }
 
+.formation-display {
+  min-width: 0;
+}
+
+.formation-label {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .modal-overlay {
   position: fixed;
   top: 0;

--- a/src/frontend/src/app/components/convention-create-en-masse/cadre-stage/cadre-stage-modal/cadre-stage-modal.component.ts
+++ b/src/frontend/src/app/components/convention-create-en-masse/cadre-stage/cadre-stage-modal/cadre-stage-modal.component.ts
@@ -203,6 +203,23 @@ export class CadreStageModalComponent implements OnInit {
     return this.formConvention.controls.inscription.value;
   }
 
+  getInscriptionLibelle(inscription: any): string {
+    return inscription?.etapeInscription?.libWebVet || '';
+  }
+
+  getFormationDisplayLabel(inscription: any): string {
+    const code = inscription?.etapeInscription?.codeEtp ?? '';
+    const libelle = this.getInscriptionLibelle(inscription);
+    return libelle ? `${code} - ${libelle}` : code;
+  }
+
+  getFormationTooltip(inscription: any): string {
+    const code = inscription?.etapeInscription?.codeEtp ?? '';
+    const libelle = this.getInscriptionLibelle(inscription);
+    const composante = inscription?.etapeInscription?.libComposante;
+    return [code, libelle, composante].filter(Boolean).join(' — ');
+  }
+
   validate(): void {
     if (this.aucunTypeConventionDisponible) {
       this.messageService.setError(this.aucunTypeConventionMessage);

--- a/src/frontend/src/app/components/convention/etudiant/etudiant.component.html
+++ b/src/frontend/src/app/components/convention/etudiant/etudiant.component.html
@@ -223,7 +223,12 @@
                         <div class="row mb-2">
                           <div class="col-sm-4 font-weight-bold">Formation</div>
                           <div class="col-sm-8 formation-display">
-                            <span>{{selectedInscription.etapeInscription.codeEtp}}{{selectedInscription.etapeInscription.libComposante != null ? ' - ' + selectedInscription.etapeInscription.libComposante : ''}}</span>
+                            <span
+                              class="formation-label"
+                              [matTooltip]="getFormationTooltip(selectedInscription)"
+                              matTooltipShowDelay="300">
+                              {{ getFormationDisplayLabel(selectedInscription) }}
+                            </span>
                             @if (modifiable && convention.id && !isEditingFormation) {
                               <button
                                 type="button"

--- a/src/frontend/src/app/components/convention/etudiant/etudiant.component.scss
+++ b/src/frontend/src/app/components/convention/etudiant/etudiant.component.scss
@@ -11,9 +11,18 @@
   align-items: center;
   display: flex;
   gap: 6px;
+  min-width: 0;
+}
+
+.formation-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .edit-formation-button{
+  flex-shrink: 0;
   width:24px;
   height:24px;
   line-height:24px;

--- a/src/frontend/src/app/components/convention/etudiant/etudiant.component.ts
+++ b/src/frontend/src/app/components/convention/etudiant/etudiant.component.ts
@@ -491,6 +491,19 @@ export class EtudiantComponent implements OnInit, OnChanges {
     return inscription?.etapeInscription?.codeComposante || null;
   }
 
+  getFormationDisplayLabel(inscription: any): string {
+    const code = inscription?.etapeInscription?.codeEtp ?? '';
+    const libelle = this.getInscriptionLibelle(inscription);
+    return libelle ? `${code} - ${libelle}` : code;
+  }
+
+  getFormationTooltip(inscription: any): string {
+    const code = inscription?.etapeInscription?.codeEtp ?? '';
+    const libelle = this.getInscriptionLibelle(inscription);
+    const composante = inscription?.etapeInscription?.libComposante;
+    return [code, libelle, composante].filter(Boolean).join(' — ');
+  }
+
   shouldDisplayFormationSelect(): boolean {
     if (!this.convention?.id) {
       return this.inscriptions.length > 1;


### PR DESCRIPTION
## Summary
- Affiche le code et l'intitulé de formation (libWebVet) sur la ligne statique de l'onglet Étudiant, y compris lorsqu'il n'y a qu'une inscription.
- Conserve une seule ligne (ellipsis) et une infobulle avec le texte complet, composante comprise.
- Applique le même affichage dans le modal de création de conventions en masse.
- Met à jour le CHANGELOG 3.3.0.

Ticket : https://github.com/EsupPortail/esup-stage/issues/112

## Test plan
- [ ] Création de convention, une seule formation : l'intitulé VET est visible sans ouvrir de liste.
- [ ] Intitulé long : une seule ligne, points de suspension, infobulle au survol.
- [ ] Clic sur le crayon : la liste reste code - intitulé (code composante).
- [ ] Création en masse : même affichage sur la ligne Formation.
- [ ] Sauvegarde : le libellé d'étape enregistré reste l'intitulé VET.