### PR TITLE
Release 3.2.7

### DIFF
--- a/src/frontend/src/app/components/centre-gestion/fiche-evaluation/fiche-evaluation.component.ts
+++ b/src/frontend/src/app/components/centre-gestion/fiche-evaluation/fiche-evaluation.component.ts
@@ -1,10 +1,13 @@
 import { Component, OnInit, Input, ViewEncapsulation } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from "@angular/forms";
+import { FormBuilder, FormGroup } from "@angular/forms";
 import { FicheEvaluationService } from "../../../services/fiche-evaluation.service";
 import { MessageService } from "../../../services/message.service";
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { QuestionSupplementaireFormComponent } from './question-supplementaire-form/question-supplementaire-form.component';
 import { ContenuService } from "../../../services/contenu.service";
+import { QuestionsEvaluationService } from "../../../services/questions-evaluation.service";
+import { forkJoin } from "rxjs";
+import { TypeQuestionEvaluation } from "../../../constants/type-question-evaluation";
 
 @Component({
     selector: 'app-fiche-evaluation',
@@ -29,639 +32,17 @@ export class FicheEvaluationComponent implements OnInit {
   ficheEnseignantForm: FormGroup;
   ficheEntrepriseForm: FormGroup;
 
-  FicheEtudiantIQuestions: any = [
-    {
-      title: "Avez-vous rencontré des difficultés pour trouver un stage ?",
-      texte: [
-              "Non, il est automatiquement proposé dans le cadre de la formation",
-              "Non, je l’ai trouvé assez facilement par moi-même",
-              "Oui j’ai eu des difficultés",
-             ],
-      controlName: "questionEtuI1",
-    },
-    {
-      title: "Combien de temps a duré votre recherche de stage ?",
-      texte: [
-              "1 jour à 1 semaine",
-              "2 semaines à 1 mois",
-              "1 mois à 3 mois",
-              "3 mois à 6 mois",
-              "+ de 6 mois",
-             ],
-      controlName: "questionEtuI2",
-    },
-    {
-      title: "Combien d'établissement(s) d'accueil avez-vous prospecté(s) ?",
-      texte: [
-              "1 à 5",
-              "6 à 10",
-              "11 à 20",
-              "20 et plus",
-             ],
-      controlName: "questionEtuI3",
-    },
-    {
-      title: "Quel(s) procédé(s) de démarchage avez-vous utilisé(s) ?",
-      texte: [
-              "Mail Oui / Non",
-              "Téléphone Oui / Non",
-              "Courrier Oui / Non",
-              "Prospection directe Oui / Non",
-             ],
-      controlName: "questionEtuI4",
-    },
-    {
-      title: "Comment avez-vous trouvé votre stage ? (récupération de l'information depuis la convention)",
-      texte: [
-              "Réponse à une offre de stage",
-              "Candidature spontanée",
-              "Réseau de connaissance",
-              "Proposé par le département",
-             ],
-      controlName: "questionEtuI5",
-    },
-    {
-      title: "Comment avez-vous déterminé le contenu de stage ?",
-      texte: [
-              "Proposé par votre tuteur professionnel",
-              "Proposé par votre tuteur enseignant",
-              "Élaboré par vous-même",
-              "Négocié entre les parties",
-             ],
-      controlName: "questionEtuI6",
-    },
-    {
-      title: "Avez-vous été accompagné(e) dans vos démarches ?",
-      texte: [
-              "Oui / Non",
-              " ",
-              "Si oui, par qui ?",
-              "    Par votre réseau personnel",
-              "    Au sein de votre formation",
-              "    Par le service d'Information, d'Orientation et d'Insertion Professionnelle",
-              "    Par le Bureau d'Aide à l'Insertion Professionnelle",
-              "    Autre",
-              " ",
-              "Si non, pourquoi ?",
-              "    Par choix",
-              "    Par méconnaissance des dispositifs proposés par votre université",
-             ],
-      controlName: "questionEtuI7",
-    },
-    {
-      title: "Est-ce que les modalités d'évaluation de stage vous ont été clairement présentées avant le début du stage ?",
-      texte: [
-              "Oui / Non",
-             ],
-      controlName: "questionEtuI8",
-    },
-  ];
+  FicheEtudiantIQuestions: any[] = [];
+  FicheEtudiantIIQuestions: any[] = [];
+  FicheEtudiantIIIQuestions: any[] = [];
+  FicheEnseignantIQuestions: any[] = [];
+  FicheEnseignantIIQuestions: any[] = [];
+  FicheEntrepriseIQuestions: any[] = [];
+  FicheEntrepriseIIQuestions: any[] = [];
+  FicheEntrepriseIIIQuestions: any[] = [];
 
-  FicheEtudiantIIQuestions: any = [
-    {
-      title: "Comment qualifieriez-vous l'accueil de votre entreprise ?",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEtuII1",
-    },
-    {
-      title: "Comment qualifieriez-vous l'encadrement de votre stage ?",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEtuII2",
-    },
-    {
-      title: "Comment qualifieriez-vous votre adaptation au sein de l'établissement d'accueil ?",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEtuII3",
-    },
-    {
-      title: "Les conditions matérielles vous ont permis d’atteindre les objectifs de votre stage :",
-      texte: [
-              "Tout à fait d'accord",
-              "Plutôt d'accord",
-              "Plutôt pas d'accord",
-              "Pas du tout d'accord",
-             ],
-      controlName: "questionEtuII4",
-    },
-    {
-      title: "Avez-vous exercé des responsabilités ?",
-      texte: [
-              "Oui / Non",
-              " ",
-              "Si oui : a) de quel ordre ?",
-              "    Très importantes",
-              "    Importantes",
-              "    Peu importantes",
-              " ",
-              "b) avec autonomie ?",
-              "    Oui / Non",
-             ],
-      controlName: "questionEtuII5",
-    },
-    {
-      title: "Votre stage avait-il une dimension internationale ?",
-      texte: [
-              "Oui / Non",
-             ],
-      controlName: "questionEtuII6",
-    },
-  ];
-
-  FicheEtudiantIIIQuestions: any = [
-    {
-      title: "Votre sujet de stage était à l'origine : (récuperation du sujet depuis la convention). L'avez-vous modifié ?",
-      texte: [
-              "Oui / Non",
-             ],
-      controlName: "questionEtuIII1",
-    },
-    {
-      title: "Selon vous, le stage a-t-il bien été en adéquation avec votre formation ?",
-      texte: [
-              "Oui / Non",
-             ],
-      controlName: "questionEtuIII2",
-    },
-    {
-      title: "Les missions confiées ont été ?",
-      texte: [
-              "Très au-dessous de vos compétences",
-              "Au-dessous de vos compétences",
-              "A votre niveau de compétences",
-              "Au-dessus de vos compétences",
-              "Très au-dessus de vos compétences",
-              "Inatteignables",
-             ],
-      controlName: "questionEtuIII4",
-    },
-    {
-      title: "Ce stage vous a-t-il permis d'acquérir :",
-      texte: [
-              "Compétences techniques Oui / Non",
-              "Nouvelles méthodologies Oui / Non",
-              "Nouvelles connaissances théoriques Oui / Non",
-             ],
-      controlName: "questionEtuIII5",
-    },
-    {
-      title: "Ce stage vous a permis de progresser dans la construction de votre projet personnel et professionnel :",
-      texte: [
-              "Tout à fait d'accord",
-              "Plutôt d'accord",
-              "Sans avis",
-              "Plutôt pas d'accord",
-              "Pas du tout d'accord",
-             ],
-      controlName: "questionEtuIII6",
-    },
-    {
-      title: "Ce stage vous paraît déterminant à cette étape de votre formation :",
-      texte: [
-              "Tout à fait d'accord",
-              "Plutôt d'accord",
-              "Sans avis",
-              "Plutôt pas d'accord",
-              "Pas du tout d'accord",
-             ],
-      controlName: "questionEtuIII7",
-    },
-    {
-      title: "Votre travail a-t-il abouti à une réorganisation du travail ?",
-      texte: [
-              "Oui / Non",
-             ],
-      controlName: "questionEtuIII8",
-    },
-    {
-      title: "Allez-vous valoriser cette expérience dans une prochaine recherche d'emploi/stage ?",
-      texte: [
-              "Oui / Non",
-             ],
-      controlName: "questionEtuIII9",
-    },
-    {
-      title: "Votre travail va-t-il donner lieu à un dépôt de brevet ?",
-      texte: [
-              "Oui / Non",
-             ],
-      controlName: "questionEtuIII10",
-    },
-    {
-      title: "Avez-vous reçu une attestation de stage ?",
-      texte: [
-              "Oui / Non",
-             ],
-      controlName: "questionEtuIII11",
-    },
-    {
-      title: "Avez-vous rencontré des difficultés à percevoir votre gratification ?",
-      texte: [
-              "Oui / Non",
-             ],
-      controlName: "questionEtuIII12",
-    },
-    {
-      title: "Ce stage a-t-il donné lieu à une proposition d'emploi ou d'alternance ?",
-      texte: [
-              "Oui / Non",
-             ],
-      controlName: "questionEtuIII14",
-    },
-    {
-      title: "Conseilleriez-vous cet établissement d'accueil à un autre étudiant ?",
-      texte: [
-              "Tout à fait d'accord",
-              "Plutôt d'accord",
-              "Sans avis",
-              "Plutôt pas d'accord",
-              "Pas du tout d'accord",
-             ],
-      controlName: "questionEtuIII15",
-    },
-    {
-      title: "Indiquez votre appréciation générale sur le stage :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEtuIII16",
-    },
-  ];
-
-  FicheEnseignantIQuestions: any = [
-    {
-      title: "Modalité(s) d’échange(s) avec le stagiaire :",
-      texte: [
-              "Téléphone Oui / Non",
-              "Mail Oui / Non",
-              "Rencontre Oui / Non",
-             ],
-      controlName: "questionEnsI1",
-    },
-    {
-      title: "Modalité(s) d’échange(s) avec le tuteur professionnel :",
-      texte: [
-              "Téléphone Oui / Non",
-              "Mail Oui / Non",
-              "Rencontre Oui / Non",
-             ],
-      controlName: "questionEnsI2",
-    },
-    {
-      title: "Commentaire(s) :",
-      texte: [
-              "Champ de texte libre",
-             ],
-      controlName: "questionEnsI3",
-    },
-  ]
-
-  FicheEnseignantIIQuestions: any = [
-    {
-      title: "Impression générale et présentation de l’étudiant :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnsII1",
-    },
-    {
-      title: "Aptitude à cerner et situer le projet :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnsII2",
-    },
-    {
-      title: "Aptitude à appliquer ses connaissances :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnsII3",
-    },
-    {
-      title: "Maîtrise du sujet, argumentation, analyse :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnsII4",
-    },
-    {
-      title: "Mise en évidence des éléments importants de l’étude :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnsII5",
-    },
-    {
-      title: "Utilisation des moyens de communication :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnsII6",
-    },
-    {
-      title: "Qualité de l’expression orale :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnsII7",
-    },
-    {
-      title: "Capacité à intéresser l’auditoire :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnsII8",
-    },
-    {
-      title: "Pertinence des réponses :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnsII9",
-    },
-    {
-      title: "Respect du temps alloué :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnsII10",
-    },
-    {
-      title: "Commentaire(s) :",
-      texte: [
-              "Champ de texte libre",
-             ],
-      controlName: "questionEnsII11",
-    },
-  ]
-
-  FicheEntrepriseIQuestions: any = [
-    {
-      title: "Adaptation au milieu professionnel :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnt1",
-    },
-    {
-      title: "Intégration au groupe de travail :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnt2",
-    },
-    {
-      title: "Assiduité - ponctualité :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnt3",
-    },
-    {
-      title: "Intérêt pour l'établissement, les services, et les métiers :",
-      texte: [
-        "Excellent",
-        "Très bien",
-        "Bien",
-        "Satisfaisant",
-        "Insuffisant",
-      ],
-      controlName: "questionEnt5",
-    },
-    {
-      title: "Sens de l'organisation :",
-      texte: [
-        "Excellent",
-        "Très bien",
-        "Bien",
-        "Satisfaisant",
-        "Insuffisant",
-      ],
-      controlName: "questionEnt9",
-    },
-    {
-      title: "Capacité d'autonomie :",
-      texte: [
-        "Excellent",
-        "Très bien",
-        "Bien",
-        "Satisfaisant",
-        "Insuffisant",
-      ],
-      controlName: "questionEnt11",
-    },
-    {
-      title: "Initiative personnelle :",
-      texte: [
-        "Excellent",
-        "Très bien",
-        "Bien",
-        "Satisfaisant",
-        "Insuffisant",
-      ],
-      controlName: "questionEnt12",
-    },
-    {
-      title: "Implication :",
-      texte: [
-        "Excellent",
-        "Très bien",
-        "Bien",
-        "Satisfaisant",
-        "Insuffisant",
-      ],
-      controlName: "questionEnt13",
-    },
-    {
-      title: "Rigueur et précision dans le travail :",
-      texte: [
-        "Excellent",
-        "Très bien",
-        "Bien",
-        "Satisfaisant",
-        "Insuffisant",
-      ],
-      controlName: "questionEnt14",
-    },
-  ]
-
-  FicheEntrepriseIIQuestions: any = [
-    {
-      title: "Aptitude à cerner et situer le projet :",
-      texte: [
-        "Excellent",
-        "Très bien",
-        "Bien",
-        "Satisfaisant",
-        "Insuffisant",
-      ],
-      controlName: "questionEnt4",
-    },
-    {
-      title: "Aptitude à appliquer ses connaissances",
-      texte: [
-        "Excellent",
-        "Très bien",
-        "Bien",
-        "Satisfaisant",
-        "Insuffisant",
-      ],
-      controlName: "questionEnt6",
-    },
-    {
-      title: "Esprit d'observation et pertinence des remarques :",
-      texte: [
-        "Excellent",
-        "Très bien",
-        "Bien",
-        "Satisfaisant",
-        "Insuffisant",
-      ],
-      controlName: "questionEnt7",
-    },
-    {
-      title: "Esprit de synthèse :",
-      texte: [
-        "Excellent",
-        "Très bien",
-        "Bien",
-        "Satisfaisant",
-        "Insuffisant",
-      ],
-      controlName: "questionEnt8",
-    },
-    {
-      title: "Aptitude à la communication :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnt15",
-    },
-  ]
-
-  FicheEntrepriseIIIQuestions: any = [
-    {
-      title: "Les objectifs ont-ils été atteints ?",
-      texte: [
-              "Tout à fait d'accord",
-              "Plutôt d'accord",
-              "Sans avis",
-              "Plutôt pas d'accord",
-              "Pas du tout d'accord",
-             ],
-      controlName: "questionEnt16",
-    },
-    {
-      title: "Indiquez votre appréciation générale de ce stage :",
-      texte: [
-              "Excellent",
-              "Très bien",
-              "Bien",
-              "Satisfaisant",
-              "Insuffisant",
-             ],
-      controlName: "questionEnt17",
-    },
-    {
-      title: "Observations :",
-      texte: [
-        "Champ de texte libre",
-      ],
-      controlName: "questionEnt19",
-    },
-    {
-      title: "Avez-vous remis au stagiaire une attestation de stage ?",
-      texte: [
-        "Oui / Non",
-      ],
-      controlName: "questionEnt10",
-    },
-    {
-      title: "Accepteriez-vous de reprendre un de nos étudiants en stage ?",
-      texte: [
-        "Oui / Non",
-      ],
-      controlName: "questionEnt18",
-    },
-  ]
+  private readonly LIKERT_5 = ['Excellent', 'Très bien', 'Bien', 'Satisfaisant', 'Insuffisant'];
+  private readonly AGREEMENT_5 = ['Tout à fait d\'accord', 'Plutôt d\'accord', 'Sans avis', 'Plutôt pas d\'accord', 'Pas du tout d\'accord'];
 
   @Input() idCentreGestion: any;
 
@@ -670,6 +51,7 @@ export class FicheEvaluationComponent implements OnInit {
               private messageService: MessageService,
               public matDialog: MatDialog,
               public contenuService: ContenuService,
+              private questionsEvaluationService: QuestionsEvaluationService,
   ) {
     this.ficheEtudiantForm = this.fb.group({
       questionEtuI1: [null],
@@ -745,9 +127,19 @@ export class FicheEvaluationComponent implements OnInit {
       this.texteAlerte = response.texte;
     });
 
+    forkJoin({
+      etu: this.questionsEvaluationService.getQuestionsEtu(),
+      ens: this.questionsEvaluationService.getQuestionsEns(),
+      ent: this.questionsEvaluationService.getQuestionsEnt(),
+    }).subscribe(({ etu, ens, ent }) => {
+      this.buildQuestionSections(etu, ens, ent);
+      this.loadFicheEvaluation();
+    });
+  }
+
+  private loadFicheEvaluation(): void {
     this.ficheEvaluationService.getByCentreGestion(this.idCentreGestion).subscribe((response: any) => {
       this.ficheEvaluation = response;
-
       this.getQuestionSupplementaire();
 
       this.ficheEtudiantForm.setValue({
@@ -820,6 +212,117 @@ export class FicheEvaluationComponent implements OnInit {
         questionEnt19: this.ficheEvaluation.questionEnt19,
       });
     });
+  }
+
+  private buildQuestionSections(etu: any[], ens: any[], ent: any[]): void {
+    this.FicheEtudiantIQuestions = [];
+    this.FicheEtudiantIIQuestions = [];
+    this.FicheEtudiantIIIQuestions = [];
+    this.FicheEnseignantIQuestions = [];
+    this.FicheEnseignantIIQuestions = [];
+    this.FicheEntrepriseIQuestions = [];
+    this.FicheEntrepriseIIQuestions = [];
+    this.FicheEntrepriseIIIQuestions = [];
+
+    for (const q of etu ?? []) {
+      this.bucketForEtu(q.code).push(this.buildPreviewQuestion(q));
+    }
+    for (const q of ens ?? []) {
+      this.bucketForEns(q.code).push(this.buildPreviewQuestion(q));
+    }
+    for (const q of ent ?? []) {
+      this.bucketForEnt(q.code).push(this.buildPreviewQuestion(q));
+    }
+  }
+
+  private bucketForEtu(code: string): any[] {
+    if (code.startsWith('ETUIII')) return this.FicheEtudiantIIIQuestions;
+    if (code.startsWith('ETUII')) return this.FicheEtudiantIIQuestions;
+    return this.FicheEtudiantIQuestions;
+  }
+
+  private bucketForEns(code: string): any[] {
+    if (code.startsWith('ENSII')) return this.FicheEnseignantIIQuestions;
+    return this.FicheEnseignantIQuestions;
+  }
+
+  private bucketForEnt(code: string): any[] {
+    if (['ENT4', 'ENT6', 'ENT7', 'ENT8', 'ENT15'].includes(code)) return this.FicheEntrepriseIIQuestions;
+    if (['ENT16', 'ENT17', 'ENT18', 'ENT19', 'ENT10'].includes(code)) return this.FicheEntrepriseIIIQuestions;
+    return this.FicheEntrepriseIQuestions;
+  }
+
+  private toControlName(code: string): string {
+    if (code.startsWith('ETU')) return 'questionEtu' + code.substring(3);
+    if (code.startsWith('ENS')) return 'questionEns' + code.substring(3);
+    if (code.startsWith('ENT')) return 'questionEnt' + code.substring(3);
+    return 'question' + code;
+  }
+
+  private parseParamsJson(paramsJson?: string | null): any {
+    if (!paramsJson) return null;
+    try {
+      return JSON.parse(paramsJson);
+    } catch {
+      return null;
+    }
+  }
+
+  private extractItems(q: any): string[] {
+    const params = this.parseParamsJson(q.paramsJson);
+    if (params?.items && Array.isArray(params.items)) {
+      return params.items.map((x: any) => String(x));
+    }
+    if (q.type === TypeQuestionEvaluation.SCALE_LIKERT_5) return this.LIKERT_5;
+    if (q.type === TypeQuestionEvaluation.SCALE_AGREEMENT_5) return this.AGREEMENT_5;
+    return [];
+  }
+
+  private buildPreviewQuestion(q: any): { title: string; texte: string[]; controlName: string } {
+    const lines: string[] = [];
+    const params = this.parseParamsJson(q.paramsJson);
+    const type = q.type as TypeQuestionEvaluation;
+
+    if (q.code === 'ETUI7') {
+      lines.push('Oui / Non');
+      if (params?.oui?.items) {
+        lines.push(' ', params.oui.label || 'Si oui, par qui ?');
+        params.oui.items.forEach((item: string) => lines.push('    ' + item));
+      }
+      if (params?.non?.items) {
+        lines.push(' ', params.non.label || 'Si non, pourquoi ?');
+        params.non.items.forEach((item: string) => lines.push('    ' + item));
+      }
+    } else if (q.code === 'ETUII5') {
+      lines.push('Oui / Non', ' ', 'Si oui : a) de quel ordre ?');
+      (params?.a?.items ?? params?.items ?? []).forEach((item: string) => lines.push('    ' + item));
+      lines.push(' ', 'b) avec autonomie ?', '    Oui / Non');
+    } else if (q.code === 'ETUIII5') {
+      const items = params?.items ?? [
+        'Compétences techniques',
+        'Nouvelles méthodologies',
+        'Nouvelles connaissances théoriques',
+      ];
+      items.forEach((item: string) => lines.push(item + ' Oui / Non'));
+    } else if (type === TypeQuestionEvaluation.YES_NO) {
+      lines.push('Oui / Non');
+      if (q.bisQuestion) lines.push(' ', q.bisQuestion);
+    } else if (type === TypeQuestionEvaluation.BOOLEAN_GROUP) {
+      this.extractItems(q).forEach(item => lines.push(item + ' Oui / Non'));
+    } else if (type === TypeQuestionEvaluation.AUTO) {
+      lines.push('(Récupération automatique depuis la convention)');
+    } else if (type === TypeQuestionEvaluation.TEXT) {
+      lines.push('Champ de texte libre');
+    } else {
+      this.extractItems(q).forEach(item => lines.push(item));
+      if (q.bisQuestion) lines.push(' ', q.bisQuestion);
+    }
+
+    return {
+      title: q.texte,
+      texte: lines.length ? lines : ['—'],
+      controlName: this.toControlName(q.code),
+    };
   }
 
   saveAndValidateFicheEtudiant(): void {

--- a/src/frontend/src/app/components/convention-create-en-masse/cadre-stage/cadre-stage-modal/cadre-stage-modal.component.html
+++ b/src/frontend/src/app/components/convention-create-en-masse/cadre-stage/cadre-stage-modal/cadre-stage-modal.component.html
@@ -131,6 +131,7 @@
                       <mat-form-field class="col-sm-12 mb-2" appearance="fill">
                         <mat-label>Élément pédagogique</mat-label>
                         <mat-select formControlName="inscriptionElp" [required]="!sansElp">
+                          <mat-option [value]="null"></mat-option>
                           <mat-option *ngFor="let elp of selectedInscription.elementPedagogiques" [value]="elp">{{elp.codElp + ' - ' + elp.libElp + ' : ' + elp.nbrCrdElp}}</mat-option>
                         </mat-select>
                         <mat-error><app-form-error [field]="formConvention.get('inscriptionElp')"></app-form-error></mat-error>

--- a/src/frontend/src/app/components/convention/etab-accueil/etab-accueil.component.html
+++ b/src/frontend/src/app/components/convention/etab-accueil/etab-accueil.component.html
@@ -79,15 +79,16 @@
       Recherchez l'établissement où le stage sera effectué
     </mat-expansion-panel-header>
 
-    <div class="sirene-info-box" *ngIf="isSireneActive">
+    <div class="sirene-info-box" *ngIf="showSireneInfo()">
       <div class="sirene-info-title">
         <mat-icon aria-hidden="true">info</mat-icon>
-        <span class="m-2">La recherche de l'établissement se fait via la base de <a href="https://annuaire-entreprises.data.gouv.fr/">l'annuaire national des entreprises</a> en renseignant :</span>
+        <span class="m-2">La recherche de l'établissement se fait via la base de <a href="https://annuaire-entreprises.data.gouv.fr/">l'annuaire national des entreprises</a>. La recherche via l’API Sirene est déclenchée uniquement si le nombre de résultats locaux est <strong>inférieur à {{nbMinResultats}}</strong>, et si :</span>
       </div>
       <div class="sirene-info-details">
         <ul>
-          <li>soit au moins <strong>2 champs de recherche</strong> (par ex : Raison sociale + Commune)</li>
-          <li>soit le <strong>SIRET</strong> de l'entreprise</li>
+          <li>au moins <strong>2 champs de recherche</strong> sont remplis (par ex : Raison sociale + Commune)</li>
+          <li>ou une <strong>recherche directe par SIRET</strong> est effectuée</li>
+          <li>le filtre Pays n’est pas utilisé, <strong>ou</strong> la <strong>France</strong> fait partie des pays sélectionnés</li>
         </ul>
       </div>
       En cas d’absence dans la liste, contactez votre gestionnaire de stage.

--- a/src/frontend/src/app/components/convention/etab-accueil/etab-accueil.component.html
+++ b/src/frontend/src/app/components/convention/etab-accueil/etab-accueil.component.html
@@ -79,6 +79,19 @@
       Recherchez l'établissement où le stage sera effectué
     </mat-expansion-panel-header>
 
+    <div class="sirene-info-box" *ngIf="isSireneActive">
+      <div class="sirene-info-title">
+        <mat-icon aria-hidden="true">info</mat-icon>
+        <span class="m-2">La recherche de l'établissement se fait via la base de <a href="https://annuaire-entreprises.data.gouv.fr/">l'annuaire national des entreprises</a> en renseignant :</span>
+      </div>
+      <div class="sirene-info-details">
+        <ul>
+          <li>soit au moins <strong>2 champs de recherche</strong> (par ex : Raison sociale + Commune)</li>
+          <li>soit le <strong>SIRET</strong> de l'entreprise</li>
+        </ul>
+      </div>
+      En cas d’absence dans la liste, contactez votre gestionnaire de stage.
+    </div>
 
     <app-table [service]="structureService" [columns]="columns" [sortColumn]="sortColumn" [filters]="filters"
                matSort [matSortActive]="sortColumn" [matSortDirection]="'asc'"

--- a/src/frontend/src/app/components/convention/etab-accueil/etab-accueil.component.ts
+++ b/src/frontend/src/app/components/convention/etab-accueil/etab-accueil.component.ts
@@ -37,7 +37,7 @@ export class EtabAccueilComponent implements OnInit {
   @Input() etab: any;
   modif: boolean = false;
   selectedRow: any = undefined;
-  isSireneAcitve: boolean = false;
+  isSireneActive: boolean = false;
   nbMinResultats: number = 0;
 
   @Input() modifiable!: boolean;
@@ -111,7 +111,7 @@ export class EtabAccueilComponent implements OnInit {
       this.currentUser = res;
     });
     this.structureService.getSireneInfo().subscribe((response: any) => {
-      this.isSireneAcitve = response.isApiSireneActive;
+      this.isSireneActive = response.isApiSireneActive;
       this.nbMinResultats = response.nombreResultats;
     });
   }

--- a/src/frontend/src/app/components/convention/etab-accueil/etab-accueil.component.ts
+++ b/src/frontend/src/app/components/convention/etab-accueil/etab-accueil.component.ts
@@ -116,6 +116,11 @@ export class EtabAccueilComponent implements OnInit {
     });
   }
 
+  showSireneInfo(): boolean {
+    return this.isSireneActive
+      && (!this.authService.isEtudiant() || !this.autorisationCreationFrance);
+  }
+
   canCreate(): boolean {
     let hasRight = this.authService.checkRights({fonction: AppFonction.ORGA_ACC, droits: [Droit.CREATION]});
     if(this.authService.isEtudiant() && !this.autorisationCreationHorsFrance && !this.autorisationCreationFrance){

--- a/src/frontend/src/app/components/convention/etudiant/etudiant.component.html
+++ b/src/frontend/src/app/components/convention/etudiant/etudiant.component.html
@@ -232,6 +232,7 @@
                     <mat-form-field class="col-sm-12 mb-2" appearance="fill">
                       <mat-label>Élément pédagogique</mat-label>
                       <mat-select formControlName="inscriptionElp" [required]="!sansElp">
+                        <mat-option [value]="null"></mat-option>
                         <mat-option *ngFor="let elp of selectedInscription.elementPedagogiques" [value]="elp">{{elp.codElp + ' - ' + elp.libElp + ' : ' + elp.nbrCrdElp + ' crédits ECTS'}}</mat-option>
                       </mat-select>
                       <mat-error><app-form-error [field]="formConvention.get('inscriptionElp')"></app-form-error></mat-error>

--- a/src/frontend/src/app/components/convention/etudiant/etudiant.component.ts
+++ b/src/frontend/src/app/components/convention/etudiant/etudiant.component.ts
@@ -577,13 +577,9 @@ export class EtudiantComponent implements OnInit, OnChanges {
       } else if (data.annee == null && this.convention?.annee) {
         data.annee = this.convention.annee.split('/')[0];
       }
-      if (this.formConvention.value.inscriptionElp) {
-        Object.assign(data, {
-          codeElp: this.formConvention.value.inscriptionElp.codElp,
-          libelleELP: this.formConvention.value.inscriptionElp.libElp,
-          creditECTS: this.formConvention.value.inscriptionElp.nbrCrdElp,
-        });
-      }
+      data.codeElp = this.formConvention.value.inscriptionElp?.codElp ?? null;
+      data.libelleELP = this.formConvention.value.inscriptionElp?.libElp ?? null;
+      data.creditECTS = this.formConvention.value.inscriptionElp?.nbrCrdElp ?? null;
       if (this.isEtudiant) {
         data.etudiantLogin = this.authService.userConnected.uid;
       } else if (this.selectedRow && this.selectedRow.uid) {

--- a/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.html
+++ b/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.html
@@ -141,22 +141,20 @@
                     <!-- ETUI7 -->
                     <ng-container *ngIf="q.code === 'ETUI7'">
                       <div *ngIf="isEtui7LegacySchema()" class="mt-2 text-sm text-muted">
-                        Réponse saisie selon l'ancien format — non réexploitable à l'export.
+                        Réponse saisie selon l'ancien format. Merci de sélectionner à nouveau la sous-option ci-dessous (l'ancienne réponse complémentaire n'est pas récupérable).
                       </div>
-                      <ng-container *ngIf="!isEtui7LegacySchema()">
-                        <div *ngIf="getMainValue(q) === true" class="mt-2">
-                          <div class="text-sm mb-1"><b>{{ getETUI7Options(q).labelOui || 'Si oui, par qui ?' }}</b></div>
-                          <mat-radio-group [formControlName]="toControlBase(q.code) + 'bis1'" style="display:grid">
-                            <mat-radio-button *ngFor="let opt of getETUI7Options(q).oui; let i = index" [value]="i">{{ opt }}</mat-radio-button>
-                          </mat-radio-group>
-                        </div>
-                        <div *ngIf="getMainValue(q) === false" class="mt-2">
-                          <div class="text-sm mb-1"><b>{{ getETUI7Options(q).labelNon || 'Si non, pourquoi ?' }}</b></div>
-                          <mat-radio-group [formControlName]="toControlBase(q.code) + 'bis2'" style="display:grid">
-                            <mat-radio-button *ngFor="let opt of getETUI7Options(q).non; let i = index" [value]="i">{{ opt }}</mat-radio-button>
-                          </mat-radio-group>
-                        </div>
-                      </ng-container>
+                      <div *ngIf="getMainValue(q) === true" class="mt-2">
+                        <div class="text-sm mb-1"><b>{{ getETUI7Options(q).labelOui || 'Si oui, par qui ?' }}</b></div>
+                        <mat-radio-group [formControlName]="toControlBase(q.code) + 'bis1'" style="display:grid">
+                          <mat-radio-button *ngFor="let opt of getETUI7Options(q).oui; let i = index" [value]="i">{{ opt }}</mat-radio-button>
+                        </mat-radio-group>
+                      </div>
+                      <div *ngIf="getMainValue(q) === false" class="mt-2">
+                        <div class="text-sm mb-1"><b>{{ getETUI7Options(q).labelNon || 'Si non, pourquoi ?' }}</b></div>
+                        <mat-radio-group [formControlName]="toControlBase(q.code) + 'bis2'" style="display:grid">
+                          <mat-radio-button *ngFor="let opt of getETUI7Options(q).non; let i = index" [value]="i">{{ opt }}</mat-radio-button>
+                        </mat-radio-group>
+                      </div>
                     </ng-container>
 
                     <!-- ETUII5 : Si oui → a) choix radio ; b) oui/non -->

--- a/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.html
+++ b/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.html
@@ -140,18 +140,23 @@
 
                     <!-- ETUI7 -->
                     <ng-container *ngIf="q.code === 'ETUI7'">
-                      <div *ngIf="getMainValue(q) === true" class="mt-2">
-                        <div class="text-sm mb-1"><b>{{ getETUI7Options(q).labelOui || 'Si oui, par qui ?' }}</b></div>
-                        <mat-radio-group [formControlName]="toControlBase(q.code) + 'bis1'" style="display:grid">
-                          <mat-radio-button *ngFor="let opt of getETUI7Options(q).oui; let i = index" [value]="i">{{ opt }}</mat-radio-button>
-                        </mat-radio-group>
+                      <div *ngIf="isEtui7LegacySchema()" class="mt-2 text-sm text-muted">
+                        Réponse saisie selon l'ancien format — non réexploitable à l'export.
                       </div>
-                      <div *ngIf="getMainValue(q) === false" class="mt-2">
-                        <div class="text-sm mb-1"><b>{{ getETUI7Options(q).labelNon || 'Si non, pourquoi ?' }}</b></div>
-                        <mat-radio-group [formControlName]="toControlBase(q.code) + 'bis2'" style="display:grid">
-                          <mat-radio-button *ngFor="let opt of getETUI7Options(q).non; let i = index" [value]="i">{{ opt }}</mat-radio-button>
-                        </mat-radio-group>
-                      </div>
+                      <ng-container *ngIf="!isEtui7LegacySchema()">
+                        <div *ngIf="getMainValue(q) === true" class="mt-2">
+                          <div class="text-sm mb-1"><b>{{ getETUI7Options(q).labelOui || 'Si oui, par qui ?' }}</b></div>
+                          <mat-radio-group [formControlName]="toControlBase(q.code) + 'bis1'" style="display:grid">
+                            <mat-radio-button *ngFor="let opt of getETUI7Options(q).oui; let i = index" [value]="i">{{ opt }}</mat-radio-button>
+                          </mat-radio-group>
+                        </div>
+                        <div *ngIf="getMainValue(q) === false" class="mt-2">
+                          <div class="text-sm mb-1"><b>{{ getETUI7Options(q).labelNon || 'Si non, pourquoi ?' }}</b></div>
+                          <mat-radio-group [formControlName]="toControlBase(q.code) + 'bis2'" style="display:grid">
+                            <mat-radio-button *ngFor="let opt of getETUI7Options(q).non; let i = index" [value]="i">{{ opt }}</mat-radio-button>
+                          </mat-radio-group>
+                        </div>
+                      </ng-container>
                     </ng-container>
 
                     <!-- ETUII5 : Si oui → a) choix radio ; b) oui/non -->

--- a/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.ts
+++ b/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.ts
@@ -75,10 +75,13 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject<void>();
   private readonly LIKERT_5 = ['Excellent','Très bien','Bien','Satisfaisant','Insuffisant'];
   private readonly AGREEMENT_5 = ['Tout à fait d\'accord','Plutôt d\'accord','Sans avis','Plutôt pas d\'accord','Pas du tout d\'accord'];
+  private readonly FALLBACK_ETUI5 = ['Réponse à une offre de stage', 'Candidature spontanée', 'Réseau de connaissance', 'Proposé par le département'];
   readonly controlsIndexToLetter = ['a','b','c','d','e','f','g','h'];
   protected readonly TypeQuestionEvaluation = TypeQuestionEvaluation;
   readonly FicheType = FicheType;
-  private optionsETUI5 = {"items":['Réponse à une offre de stage', 'Candidature spontanée', 'Réseau de connaissance', 'Proposé par le département']}.items;
+  private optionsETUI5: string[] = [...this.FALLBACK_ETUI5];
+  /** Correspondance contrôle → intitulé affiché (message d'incomplétude). */
+  private controlLabels = new Map<string, string>();
 
 
 
@@ -91,120 +94,120 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
     private matDialog: MatDialog,
     private questionsEvaluationService: QuestionsEvaluationService,
   ) {
-    // --- forms init (inchangé fonctionnellement) ---
+    // Contrôles créés sans validateur : syncValidators est la seule source d'obligation.
     this.reponseEtudiantForm = this.fb.group({
-      reponseEtuI1: [null, [Validators.required]],
+      reponseEtuI1: [null],
       reponseEtuI1bis: [null],
-      reponseEtuI2: [null, [Validators.required]],
-      reponseEtuI3: [null, [Validators.required]],
-      reponseEtuI4a: [null, [Validators.required]],
-      reponseEtuI4b: [null, [Validators.required]],
-      reponseEtuI4c: [null, [Validators.required]],
-      reponseEtuI4d: [null, [Validators.required]],
+      reponseEtuI2: [null],
+      reponseEtuI3: [null],
+      reponseEtuI4a: [null],
+      reponseEtuI4b: [null],
+      reponseEtuI4c: [null],
+      reponseEtuI4d: [null],
       reponseEtuI5: [null],
-      reponseEtuI6: [null, [Validators.required]],
-      reponseEtuI7: [null, [Validators.required]],
+      reponseEtuI6: [null],
+      reponseEtuI7: [null],
       reponseEtuI7bis1: [null],
       reponseEtuI7bis1a: [null],
       reponseEtuI7bis1b: [null],
       reponseEtuI7bis2: [null],
-      reponseEtuI8: [null, [Validators.required]],
-      reponseEtuII1: [null, [Validators.required]],
+      reponseEtuI8: [null],
+      reponseEtuII1: [null],
       reponseEtuII1bis: [null],
-      reponseEtuII2: [null, [Validators.required]],
+      reponseEtuII2: [null],
       reponseEtuII2bis: [null],
-      reponseEtuII3: [null, [Validators.required]],
+      reponseEtuII3: [null],
       reponseEtuII3bis: [null],
-      reponseEtuII4: [null, [Validators.required]],
-      reponseEtuII5: [null, [Validators.required]],
+      reponseEtuII4: [null],
+      reponseEtuII5: [null],
       reponseEtuII5a: [null],
       reponseEtuII5b: [null],
-      reponseEtuII6: [null, [Validators.required]],
-      reponseEtuIII1: [null, [Validators.required]],
+      reponseEtuII6: [null],
+      reponseEtuIII1: [null],
       reponseEtuIII1bis: [null],
-      reponseEtuIII2: [null, [Validators.required]],
+      reponseEtuIII2: [null],
       reponseEtuIII2bis: [null],
-      reponseEtuIII4: [null, [Validators.required]],
-      reponseEtuIII5a: [null, [Validators.required]],
-      reponseEtuIII5b: [null, [Validators.required]],
-      reponseEtuIII5c: [null, [Validators.required]],
+      reponseEtuIII4: [null],
+      reponseEtuIII5a: [null],
+      reponseEtuIII5b: [null],
+      reponseEtuIII5c: [null],
       reponseEtuIII5bis: [null],
-      reponseEtuIII6: [null, [Validators.required]],
+      reponseEtuIII6: [null],
       reponseEtuIII6bis: [null],
-      reponseEtuIII7: [null, [Validators.required]],
+      reponseEtuIII7: [null],
       reponseEtuIII7bis: [null],
-      reponseEtuIII8: [null, [Validators.required]],
+      reponseEtuIII8: [null],
       reponseEtuIII8bis: [null],
-      reponseEtuIII9: [null, [Validators.required]],
+      reponseEtuIII9: [null],
       reponseEtuIII9bis: [null],
-      reponseEtuIII10: [null, [Validators.required]],
-      reponseEtuIII11: [null, [Validators.required]],
-      reponseEtuIII12: [null, [Validators.required]],
-      reponseEtuIII14: [null, [Validators.required]],
-      reponseEtuIII15: [null, [Validators.required]],
+      reponseEtuIII10: [null],
+      reponseEtuIII11: [null],
+      reponseEtuIII12: [null],
+      reponseEtuIII14: [null],
+      reponseEtuIII15: [null],
       reponseEtuIII15bis: [null],
-      reponseEtuIII16: [null, [Validators.required]],
-      reponseEtuIII16bis: [null, [Validators.required]],
+      reponseEtuIII16: [null],
+      reponseEtuIII16bis: [null],
     });
 
     this.reponseEnseignantForm = this.fb.group({
-      reponseEnsI1a: [null, [Validators.required]],
-      reponseEnsI1b: [null, [Validators.required]],
-      reponseEnsI1c: [null, [Validators.required]],
-      reponseEnsI2a: [null, [Validators.required]],
-      reponseEnsI2b: [null, [Validators.required]],
-      reponseEnsI2c: [null, [Validators.required]],
-      reponseEnsI3: [null, [Validators.required]],
-      reponseEnsII1: [null, [Validators.required]],
-      reponseEnsII10: [null, [Validators.required]],
-      reponseEnsII11: [null, [Validators.required]],
-      reponseEnsII2: [null, [Validators.required]],
-      reponseEnsII3: [null, [Validators.required]],
-      reponseEnsII4: [null, [Validators.required]],
-      reponseEnsII5: [null, [Validators.required]],
-      reponseEnsII6: [null, [Validators.required]],
-      reponseEnsII7: [null, [Validators.required]],
-      reponseEnsII8: [null, [Validators.required]],
-      reponseEnsII9: [null, [Validators.required]],
+      reponseEnsI1a: [null],
+      reponseEnsI1b: [null],
+      reponseEnsI1c: [null],
+      reponseEnsI2a: [null],
+      reponseEnsI2b: [null],
+      reponseEnsI2c: [null],
+      reponseEnsI3: [null],
+      reponseEnsII1: [null],
+      reponseEnsII10: [null],
+      reponseEnsII11: [null],
+      reponseEnsII2: [null],
+      reponseEnsII3: [null],
+      reponseEnsII4: [null],
+      reponseEnsII5: [null],
+      reponseEnsII6: [null],
+      reponseEnsII7: [null],
+      reponseEnsII8: [null],
+      reponseEnsII9: [null],
     });
 
     this.reponseEntrepriseForm = this.fb.group({
-      reponseEnt1: [null, [Validators.required]],
+      reponseEnt1: [null],
       reponseEnt1bis: [null],
-      reponseEnt2: [null, [Validators.required]],
+      reponseEnt2: [null],
       reponseEnt2bis: [null],
-      reponseEnt3: [null, [Validators.required]],
-      reponseEnt4: [null, [Validators.required]],
+      reponseEnt3: [null],
+      reponseEnt4: [null],
       reponseEnt4bis: [null],
-      reponseEnt5: [null, [Validators.required]],
+      reponseEnt5: [null],
       reponseEnt5bis: [null],
-      reponseEnt6: [null, [Validators.required]],
+      reponseEnt6: [null],
       reponseEnt6bis: [null],
-      reponseEnt7: [null, [Validators.required]],
+      reponseEnt7: [null],
       reponseEnt7bis: [null],
-      reponseEnt8: [null, [Validators.required]],
+      reponseEnt8: [null],
       reponseEnt8bis: [null],
-      reponseEnt9: [null, [Validators.required]],
+      reponseEnt9: [null],
       reponseEnt9bis: [null],
-      reponseEnt10: [null, [Validators.required]],
+      reponseEnt10: [null],
       reponseEnt10bis: [null],
-      reponseEnt11: [null, [Validators.required]],
+      reponseEnt11: [null],
       reponseEnt11bis: [null],
-      reponseEnt12: [null, [Validators.required]],
+      reponseEnt12: [null],
       reponseEnt12bis: [null],
-      reponseEnt13: [null, [Validators.required]],
+      reponseEnt13: [null],
       reponseEnt13bis: [null],
-      reponseEnt14: [null, [Validators.required]],
+      reponseEnt14: [null],
       reponseEnt14bis: [null],
-      reponseEnt15: [null, [Validators.required]],
+      reponseEnt15: [null],
       reponseEnt15bis: [null],
-      reponseEnt16: [null, [Validators.required]],
+      reponseEnt16: [null],
       reponseEnt16bis: [null],
-      reponseEnt17: [null, [Validators.required]],
+      reponseEnt17: [null],
       reponseEnt17bis: [null],
-      reponseEnt18: [null, [Validators.required]],
+      reponseEnt18: [null],
       reponseEnt18bis: [null],
-      reponseEnt19: [null, [Validators.required]],
+      reponseEnt19: [null],
     });
 
     this.reponseSupplementaireEtudiantForm = this.fb.group({});
@@ -232,8 +235,8 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
         this.applyDbQuestions(ens, this.FicheEnseignantIQuestions, this.FicheEnseignantIIQuestions);
         this.applyDbQuestions(ent, this.FicheEntrepriseIQuestions, this.FicheEntrepriseIIQuestions, this.FicheEntrepriseIIIQuestions);
 
-        this.wireConditionalValidators();
-        this.applyFicheVisibilityToValidators();
+        this.wireValidatorSync();
+        this.syncAllValidators();
 
         this.reponseEvaluation = rep ?? null;
         if (rep) {
@@ -249,14 +252,11 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
           this.reponseEtudiantForm.patchValue(repToPatch);
           this.reponseEnseignantForm.patchValue(rep);
           this.reponseEntrepriseForm.patchValue(rep);
-          this.refreshConditionalQuestions();
         }
+        // patchValue émet valueChanges, mais on resynchronise pour les questions sans contrôle principal (BOOLEAN_GROUP)
+        this.syncAllValidators();
         this.getQuestionSupplementaire();
-
-        const vI5 = this.getAutoValue('ETUI5');
         this.setAutoEtuI5();
-        this.setRequired(this.reponseEtudiantForm, ['reponseEtuI5'], !!vI5);
-        this.setRequired(this.reponseEtudiantForm, ['reponseEtuI7bis'], false);
       });
   }
 
@@ -273,16 +273,6 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
       case FicheType.Enseignant: return this.reponseEnseignantForm;
       case FicheType.Entreprise: return this.reponseEntrepriseForm;
     }
-  }
-
-  private toggleValidators(form: FormGroup, keys: string[], required: boolean): void {
-    keys.forEach(key => {
-      const c = form.get(key);
-      if (!c) return;
-      if (required) c.addValidators(Validators.required);
-      else c.clearValidators();
-      c.updateValueAndValidity({ emitEvent: false });
-    });
   }
 
   // ---------------- Sauvegarde ----------------
@@ -303,11 +293,11 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
 
     const valid = form.valid && supplForm.valid;
     const data = { ...form.value };
+    const invalidMain = valid ? [] : this.listInvalidControls(form);
+    const invalidSuppl = valid ? [] : this.listInvalidControls(supplForm, 'suppl');
+    const invalidPaths = [...invalidMain, ...invalidSuppl].map(x => x.path);
 
     if (!valid) {
-      const invalidMain = this.listInvalidControls(form);
-      const invalidSuppl = this.listInvalidControls(supplForm, 'suppl');
-
       console.groupCollapsed(
         `%c[EvaluationStage] Champs invalides (type=${FicheType[typeFiche]})`,
         'color:#d32f2f;font-weight:bold;'
@@ -322,10 +312,6 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
 
       console.warn('Form principal INVALID =>', pretty(invalidMain));
       console.warn('Form suppl. INVALID =>', pretty(invalidSuppl));
-
-      // Optionnel : filtrer les "bases" des BOOLEAN_GROUP si tu en as encore
-      // console.warn('Sans bases BOOLEAN_GROUP =>', pretty(invalidMain.filter(i => !/reponse(Etu|Ens|Ent).*[a-z]$/.test(i.path))));
-
       console.groupEnd();
     }
 
@@ -348,8 +334,11 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
 
     const onDone = (response: any) => {
       this.reponseEvaluation = response;
-      if (valid) this.messageService.setSuccess('Evaluation enregistrée avec succès');
-      else this.messageService.setWarning('Evaluation enregistrée avec succès, mais certains champs restent à remplir');
+      if (valid) {
+        this.messageService.setSuccess('Evaluation enregistrée avec succès');
+      } else {
+        this.messageService.setWarning(this.buildIncompleteWarning(invalidPaths));
+      }
     };
 
     const calls = {
@@ -365,6 +354,23 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
     } as const;
 
     calls[typeFiche]().pipe(takeUntil(this.destroy$)).subscribe(onDone);
+  }
+
+  private buildIncompleteWarning(paths: string[]): string {
+    const labels = [...new Set(
+      paths.map(p => {
+        const key = p.startsWith('suppl.') ? p.slice('suppl.'.length) : p;
+        return this.controlLabels.get(key) || this.controlLabels.get(p) || key;
+      })
+    )];
+    const max = 5;
+    const shown = labels.slice(0, max);
+    const rest = labels.length - shown.length;
+    let detail = shown.join(' ; ');
+    if (rest > 0) detail += ` ; et ${rest} autre${rest > 1 ? 's' : ''}`;
+    return labels.length
+      ? `Evaluation enregistrée, mais des champs restent à remplir : ${detail}`
+      : 'Evaluation enregistrée avec succès, mais certains champs restent à remplir';
   }
 
   // ---------------- Impression / Modale ----------------
@@ -417,6 +423,7 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
             form.addControl(name, new FormControl(null, validator));
           }
           q.formControlName = name;
+          if (q.question) this.controlLabels.set(name, q.question);
 
           if (this.reponseEvaluation) {
             this.reponseEvaluationService.getReponseSupplementaire(this.convention.id, q.id)
@@ -500,22 +507,19 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
 
     const base = this.toControlBase(vm.code);
 
-    // Ne pas mettre de required sur le "base" des BOOLEAN_GROUP
-    const needBaseRequired = vm.type !== TypeQuestionEvaluation.BOOLEAN_GROUP;
-
     if (!form.contains(base)) {
-      form.addControl(base, new FormControl(null, needBaseRequired ? Validators.required : []));
+      form.addControl(base, new FormControl(null));
     }
 
     if (vm.type === TypeQuestionEvaluation.BOOLEAN_GROUP && Array.isArray(vm.options)) {
       vm.options.forEach((_, i) => {
         const key = base + this.controlsIndexToLetter[i];
-        if (!form.contains(key)) form.addControl(key, new FormControl(null, this.requiredNonNull));
+        if (!form.contains(key)) form.addControl(key, new FormControl(null));
       });
     }
 
-    // Bis générique
-    if ((vm.bisQuestion || vm.bisQuestionLowNotation || vm.bisQuestionTrue || vm.bisQuestionFalse) && !form.contains(base + 'bis')) {
+    // Bis texte uniquement s'il y a un libellé affichable (évite le fantôme ETUI7)
+    if (vm.bisQuestion && !form.contains(base + 'bis')) {
       form.addControl(base + 'bis', new FormControl(null));
     }
 
@@ -526,6 +530,31 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
     if (vm.code === 'ETUII5') {
       if (!form.contains(base + 'a')) form.addControl(base + 'a', new FormControl(null));
       if (!form.contains(base + 'b')) form.addControl(base + 'b', new FormControl(null));
+    }
+
+    this.registerControlLabels(vm, base);
+  }
+
+  private registerControlLabels(vm: DbQuestion, base: string): void {
+    if (vm.texte) this.controlLabels.set(base, vm.texte);
+
+    if (vm.type === TypeQuestionEvaluation.BOOLEAN_GROUP && Array.isArray(vm.options)) {
+      vm.options.forEach((opt, i) => {
+        const key = base + this.controlsIndexToLetter[i];
+        this.controlLabels.set(key, opt ? `${vm.texte} — ${opt}` : vm.texte);
+      });
+    }
+
+    if (vm.bisQuestion) this.controlLabels.set(base + 'bis', vm.bisQuestion);
+
+    if (vm.code === 'ETUI7') {
+      const opts = this.getETUI7Options(vm);
+      this.controlLabels.set(base + 'bis1', opts.labelOui || 'Si oui, par qui ?');
+      this.controlLabels.set(base + 'bis2', opts.labelNon || 'Si non, pourquoi ?');
+    }
+    if (vm.code === 'ETUII5') {
+      this.controlLabels.set(base + 'a', 'Si oui : a) De quel ordre ?');
+      this.controlLabels.set(base + 'b', 'b) Avec autonomie ?');
     }
   }
 
@@ -551,6 +580,11 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
       if (idx > -1) target[idx] = { ...target[idx], ...vm };
       else target.push(vm);
       this.ensureFormControls(vm);
+
+      if (vm.code === 'ETUI5') {
+        const fromParams = this.parseParamsJsonLooseArr(vm.paramsJson);
+        this.optionsETUI5 = fromParams.length ? fromParams : [...this.FALLBACK_ETUI5];
+      }
     }
   }
 
@@ -567,70 +601,68 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
     return !!this.ficheEvaluation[key];
   }
 
-  private applyVisibilityForQuestion(form: FormGroup, q: any): void {
+  /**
+   * Unique assignateur de validateurs : obligation dérivée des mêmes prédicats
+   * que le template (isQuestionActive, options, shouldShowBis, Oui/Non).
+   */
+  private syncValidators(form: FormGroup, q: DbQuestion): void {
     const active = this.isQuestionActive(q.code);
     const base = this.toControlBase(q.code);
+    const mainVal = form.get(base)?.value;
 
-    const mainKeys: string[] =
-      q.type === TypeQuestionEvaluation.BOOLEAN_GROUP
-        ? (q.options || []).map((_: string, i: number) => base + this.controlsIndexToLetter[i])
-        : [base];
+    if (q.type === TypeQuestionEvaluation.BOOLEAN_GROUP) {
+      this.setRequired(form, [base], false);
+      const options = q.options || [];
+      for (let i = 0; i < this.controlsIndexToLetter.length; i++) {
+        const key = base + this.controlsIndexToLetter[i];
+        if (!form.contains(key)) continue;
+        this.setRequired(form, [key], active && i < options.length, TypeQuestionEvaluation.BOOLEAN_GROUP);
+      }
+    } else if (q.type === TypeQuestionEvaluation.AUTO) {
+      this.setRequired(form, [base], false);
+    } else {
+      this.setRequired(form, [base], active, q.type);
+    }
 
-    this.setRequired(form, mainKeys, active && q.type !== TypeQuestionEvaluation.AUTO, q.type);
+    // Affichage (shouldShowBis) ≠ obligation : les bis ENT sont souvent visibles mais optionnels
+    this.setRequired(form, [base + 'bis'], active && this.shouldRequireBis(q, mainVal));
 
-    if (!active) {
-      const conditionalKeys: string[] = [];
-      if (q.bisQuestionLowNotation || q.bisQuestionTrue || q.bisQuestionFalse) conditionalKeys.push(base + 'bis');
-      if (q.code === 'ETUI7') conditionalKeys.push(base + 'bis1', base + 'bis2');
-      if (q.code === 'ETUII5') conditionalKeys.push(base + 'a', base + 'b');
-      this.setRequired(form, conditionalKeys, false);
+    if (q.code === 'ETUI7') {
+      this.setRequired(form, [base + 'bis1'], active && !!mainVal, TypeQuestionEvaluation.SINGLE_CHOICE);
+      this.setRequired(form, [base + 'bis2'], active && mainVal === false, TypeQuestionEvaluation.SINGLE_CHOICE);
+    }
+
+    if (q.code === 'ETUII5') {
+      this.setRequired(form, [base + 'a'], active && !!mainVal, TypeQuestionEvaluation.SINGLE_CHOICE);
+      this.setRequired(form, [base + 'b'], active && !!mainVal, TypeQuestionEvaluation.YES_NO);
     }
   }
 
-  private applyFicheVisibilityToValidators(): void {
+  private syncAllValidators(): void {
     [...this.FicheEtudiantIQuestions, ...this.FicheEtudiantIIQuestions, ...this.FicheEtudiantIIIQuestions]
-      .forEach(q => this.applyVisibilityForQuestion(this.reponseEtudiantForm, q));
+      .forEach(q => this.syncValidators(this.reponseEtudiantForm, q));
     [...this.FicheEnseignantIQuestions, ...this.FicheEnseignantIIQuestions]
-      .forEach(q => this.applyVisibilityForQuestion(this.reponseEnseignantForm, q));
+      .forEach(q => this.syncValidators(this.reponseEnseignantForm, q));
     [...this.FicheEntrepriseIQuestions, ...this.FicheEntrepriseIIQuestions, ...this.FicheEntrepriseIIIQuestions]
-      .forEach(q => this.applyVisibilityForQuestion(this.reponseEntrepriseForm, q));
+      .forEach(q => this.syncValidators(this.reponseEntrepriseForm, q));
   }
 
-  private wireConditionalValidators(): void {
+  private wireValidatorSync(): void {
     const attach = (form: FormGroup, q: DbQuestion) => {
       const base = this.toControlBase(q.code);
       const main = form.get(base);
       if (!main) return;
-
-      main.valueChanges.subscribe(val => {
-        if (!this.isQuestionActive(q.code)) return;
-
-        // bis : required si condition remplie
-        const wantBis = !!(
-          (q.bisQuestionLowNotation && typeof val === 'number' && val >= 3) ||
-          (q.bisQuestionTrue && !!val) ||
-          (q.bisQuestionFalse && val === false)
-        );
-
-        this.setRequired(form, [base + 'bis'], wantBis);
-
-        // ETUI7
-        if (q.code === 'ETUI7') {
-          this.setRequired(form, [base + 'bis1'], !!val, TypeQuestionEvaluation.SINGLE_CHOICE); // index requis
-          this.setRequired(form, [base + 'bis2'], val === false, TypeQuestionEvaluation.SINGLE_CHOICE);
-        }
-
-        // ETUII5 : a = index requis, b = booléen requisNonNull
-        if (q.code === 'ETUII5') {
-          this.setRequired(form, [base + 'a'], !!val, TypeQuestionEvaluation.SINGLE_CHOICE);
-          this.setRequired(form, [base + 'b'], !!val, TypeQuestionEvaluation.YES_NO); // << booléen
-        }
-      });
+      main.valueChanges
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(() => this.syncValidators(form, q));
     };
 
-    [...this.FicheEtudiantIQuestions, ...this.FicheEtudiantIIQuestions, ...this.FicheEtudiantIIIQuestions].forEach(q => attach(this.reponseEtudiantForm, q));
-    [...this.FicheEnseignantIQuestions, ...this.FicheEnseignantIIQuestions].forEach(q => attach(this.reponseEnseignantForm, q));
-    [...this.FicheEntrepriseIQuestions, ...this.FicheEntrepriseIIQuestions, ...this.FicheEntrepriseIIIQuestions].forEach(q => attach(this.reponseEntrepriseForm, q));
+    [...this.FicheEtudiantIQuestions, ...this.FicheEtudiantIIQuestions, ...this.FicheEtudiantIIIQuestions]
+      .forEach(q => attach(this.reponseEtudiantForm, q));
+    [...this.FicheEnseignantIQuestions, ...this.FicheEnseignantIIQuestions]
+      .forEach(q => attach(this.reponseEnseignantForm, q));
+    [...this.FicheEntrepriseIQuestions, ...this.FicheEntrepriseIIQuestions, ...this.FicheEntrepriseIIIQuestions]
+      .forEach(q => attach(this.reponseEntrepriseForm, q));
   }
 
   // ---------------- AUTO / Params helpers ----------------
@@ -704,15 +736,18 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
       return true;
     }
 
-    // Flags pilotés par la base
-    if (q.bisQuestionLowNotation && typeof v === 'number' && v >= 3) return true; // 0..4
-    if (q.bisQuestionTrue && v === true) return true;
-    if (q.bisQuestionFalse && v === false) return true;
+    return this.shouldRequireBis(q, v);
+  }
 
-    // Cas legacy explicite
-    if (q.code === 'ETUIII1') return v === true;
-
-    return false;
+  /** Obligation du champ bis texte (flags base + texte bisQuestion). */
+  private shouldRequireBis(q: DbQuestion, val: any): boolean {
+    if (!q?.bisQuestion) return false;
+    return !!(
+      (q.bisQuestionLowNotation && typeof val === 'number' && val >= 3) ||
+      (q.bisQuestionTrue && val === true) ||
+      (q.bisQuestionFalse && val === false) ||
+      (q.code === 'ETUIII1' && val === true)
+    );
   }
 
   getMainValue(q: DbQuestion): any {
@@ -784,14 +819,8 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
     const idx = this.optionsETUI5.indexOf(libelle);
     const ctrl = this.reponseEtudiantForm.get('reponseEtuI5');
     if (!ctrl) return;
-    if (idx >= 0) {
-      ctrl.setValue(idx);            // ✅ on envoie un number
-      this.setRequired(this.reponseEtudiantForm, ['reponseEtuI5'], true);
-    } else {
-      // Pas de correspondance → on n’envoie rien et on ne bloque pas la validation
-      ctrl.setValue(null);
-      this.setRequired(this.reponseEtudiantForm, ['reponseEtuI5'], false);
-    }
+    // AUTO : jamais obligatoire. Index si correspondance, sinon null (export via origineStageLibelle).
+    ctrl.setValue(idx >= 0 ? idx : null, { emitEvent: false });
   }
 
   getLongTextControl(name: string): AbstractControl | null {
@@ -814,15 +843,6 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
     if (value === null || value === undefined || value === '') return null;
     const n = Number(value);
     return Number.isFinite(n) ? n : null;
-  }
-
-  private refreshConditionalQuestions(): void {
-    const etui7Ctrl = this.reponseEtudiantForm.get('reponseEtuI7');
-    if (!etui7Ctrl) return;
-    // valueChanges ne se déclenche pas au patchValue : forcer l'application des validateurs ETUI7
-    const val = etui7Ctrl.value;
-    this.setRequired(this.reponseEtudiantForm, ['reponseEtuI7bis1'], !!val, TypeQuestionEvaluation.SINGLE_CHOICE);
-    this.setRequired(this.reponseEtudiantForm, ['reponseEtuI7bis2'], val === false, TypeQuestionEvaluation.SINGLE_CHOICE);
   }
 
 

--- a/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.ts
+++ b/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.ts
@@ -242,10 +242,14 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
           if (schemaVersion < 2) {
             repToPatch.reponseEtuI7bis1 = null;
             repToPatch.reponseEtuI7bis2 = null;
+          } else {
+            repToPatch.reponseEtuI7bis1 = this.coerceIndex(repToPatch.reponseEtuI7bis1);
+            repToPatch.reponseEtuI7bis2 = this.coerceIndex(repToPatch.reponseEtuI7bis2);
           }
           this.reponseEtudiantForm.patchValue(repToPatch);
           this.reponseEnseignantForm.patchValue(rep);
           this.reponseEntrepriseForm.patchValue(rep);
+          this.refreshConditionalQuestions();
         }
         this.getQuestionSupplementaire();
 
@@ -633,10 +637,18 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
 
   getAutoValue(code: string): string {
     switch (code) {
-      case 'ETUI5': return this.convention?.origineStage?.libelle || '';
+      case 'ETUI5':
+        return this.convention?.origineStage?.libelle
+          || this.convention?.nomenclature?.origineStage
+          || '';
       case 'ETUIII0': return this.convention?.sujetStage || '';
       default: return '';
     }
+  }
+
+  isEtui7LegacySchema(): boolean {
+    const v = this.reponseEvaluation?.schemaVersion;
+    return v == null || v < 2;
   }
 
   toControlBase(code: string): string {
@@ -660,7 +672,24 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
     const non = Array.isArray(obj?.non?.items) ? obj.non.items : [];
     const labelOui = typeof obj?.oui?.label === 'string' ? obj.oui.label : undefined;
     const labelNon = typeof obj?.non?.label === 'string' ? obj.non.label : undefined;
-    return { oui, non, labelOui, labelNon };
+    if (oui.length || non.length) {
+      return { oui, non, labelOui, labelNon };
+    }
+    return {
+      oui: [
+        'Proposé par votre tuteur professionnel',
+        'Proposé par votre tuteur enseignant',
+        'Élaboré par vous-même',
+        'Négocié entre les parties',
+        'Autre'
+      ],
+      non: [
+        'Je n\'ai pas eu besoin d\'aide',
+        'Je ne savais pas à qui m\'adresser'
+      ],
+      labelOui: 'Si oui, par qui ?',
+      labelNon: 'Si non, pourquoi ?'
+    };
   }
 
   /** Affichage du bloc “bis” texte */
@@ -751,7 +780,7 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
   }
 
   private setAutoEtuI5(): void {
-    const libelle = this.convention?.origineStage?.libelle ?? '';
+    const libelle = this.getAutoValue('ETUI5');
     const idx = this.optionsETUI5.indexOf(libelle);
     const ctrl = this.reponseEtudiantForm.get('reponseEtuI5');
     if (!ctrl) return;
@@ -779,6 +808,19 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
   isLongTextLimitReached(name: string): boolean {
     const value = this.getLongTextControl(name)?.value;
     return typeof value === 'string' && value.length >= this.MAX_LENTGH_INPUT.longText;
+  }
+
+  private coerceIndex(value: unknown): number | null {
+    if (value === null || value === undefined || value === '') return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  private refreshConditionalQuestions(): void {
+    const etui7Ctrl = this.reponseEtudiantForm.get('reponseEtuI7');
+    if (etui7Ctrl) {
+      etui7Ctrl.updateValueAndValidity({ emitEvent: true });
+    }
   }
 
 

--- a/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.ts
+++ b/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.ts
@@ -237,7 +237,13 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
 
         this.reponseEvaluation = rep ?? null;
         if (rep) {
-          this.reponseEtudiantForm.patchValue(rep);
+          const repToPatch = { ...rep };
+          const schemaVersion = rep.schemaVersion == null || rep.schemaVersion < 2 ? 1 : rep.schemaVersion;
+          if (schemaVersion < 2) {
+            repToPatch.reponseEtuI7bis1 = null;
+            repToPatch.reponseEtuI7bis2 = null;
+          }
+          this.reponseEtudiantForm.patchValue(repToPatch);
           this.reponseEnseignantForm.patchValue(rep);
           this.reponseEntrepriseForm.patchValue(rep);
         }
@@ -689,12 +695,16 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
   }
 
   public getETUII5Options(q: any): { a: string[] } {
+    const schemaVersion = this.reponseEvaluation?.schemaVersion == null || this.reponseEvaluation.schemaVersion < 2 ? 1 : 2;
+    if (schemaVersion < 2) {
+      return { a: ['Très importantes', 'Importantes', 'Peu importantes'] };
+    }
     const obj = this.parseObjectLoose(q?.paramsJson);
     const aFromJson: string[] = Array.isArray(obj?.a) ? obj.a : [];
     if (aFromJson.length) return { a: aFromJson };
 
     const opts: string[] = Array.isArray(q?.options) ? q.options : [];
-    if (!opts.length) return { a: ["Technique", "Organisationnelle", "Communication"] };
+    if (!opts.length) return { a: ['Technique', 'Organisationnelle', 'Communication'] };
     return { a: opts };
   }
 

--- a/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.ts
+++ b/src/frontend/src/app/components/convention/evaluation-stage/evaluation-stage.component.ts
@@ -818,9 +818,11 @@ export class EvaluationStageComponent implements OnInit, OnDestroy {
 
   private refreshConditionalQuestions(): void {
     const etui7Ctrl = this.reponseEtudiantForm.get('reponseEtuI7');
-    if (etui7Ctrl) {
-      etui7Ctrl.updateValueAndValidity({ emitEvent: true });
-    }
+    if (!etui7Ctrl) return;
+    // valueChanges ne se déclenche pas au patchValue : forcer l'application des validateurs ETUI7
+    const val = etui7Ctrl.value;
+    this.setRequired(this.reponseEtudiantForm, ['reponseEtuI7bis1'], !!val, TypeQuestionEvaluation.SINGLE_CHOICE);
+    this.setRequired(this.reponseEtudiantForm, ['reponseEtuI7bis2'], val === false, TypeQuestionEvaluation.SINGLE_CHOICE);
   }
 
 

--- a/src/frontend/src/app/components/convention/stage/stage.component.spec.ts
+++ b/src/frontend/src/app/components/convention/stage/stage.component.spec.ts
@@ -17,6 +17,8 @@ import { OrigineStageService } from "../../../services/origine-stage.service";
 import { NatureTravailService } from "../../../services/nature-travail.service";
 import { ModeValidationStageService } from "../../../services/mode-validation-stage.service";
 import { PeriodeInterruptionStageService } from "../../../services/periode-interruption-stage.service";
+import { PeriodeStageService } from "../../../services/periode-stage.service";
+import { TypeConventionService } from "../../../services/type-convention.service";
 import { MatDialog } from '@angular/material/dialog';
 
 describe('StageComponent', () => {
@@ -44,6 +46,8 @@ describe('StageComponent', () => {
         { provide: NatureTravailService, useValue: { getPaginated: () => of({ data: [] }) } },
         { provide: ModeValidationStageService, useValue: { getPaginated: () => of({ data: [] }) } },
         { provide: PeriodeInterruptionStageService, useValue: { getByConvention: () => of([]), create: () => of({}), update: () => of({}), delete: () => of({}), deleteByConvention: () => of({}) } },
+        { provide: PeriodeStageService, useValue: { getByConvention: () => of([]), create: () => of({}), update: () => of({}), delete: () => of({}), deleteByConvention: () => of({}) } },
+        { provide: TypeConventionService, useValue: { getPaginated: () => of({ data: [] }) } },
         { provide: MatDialog, useValue: { open: () => ({ afterClosed: () => of([]) }) } }
       ]
     })
@@ -137,5 +141,56 @@ describe('StageComponent', () => {
     ];
     const result = component.calculHeuresTravails(periodes);
     expect(result).toBe(105); // 17.5 + 35 + 17.5 + 35
+  });
+
+  describe('validateForm - periodes de travail', () => {
+    let fb: FormBuilder;
+    let lastStatus: number | undefined;
+
+    beforeEach(() => {
+      fb = TestBed.inject(FormBuilder);
+      lastStatus = undefined;
+      component.validated.subscribe((status: number) => lastStatus = status);
+      component.form = fb.group({
+        horairesReguliers: [false],
+        interruptionStage: [false],
+      });
+      component.periodesInterruptionsValid = true;
+    });
+
+    it('should emit status 1 when irregular hours without periods', () => {
+      component.periodesCalculHeuresStage = [];
+      component.checkPeriodesTravailValid();
+      expect(lastStatus).toBe(1);
+    });
+
+    it('should emit status 2 when irregular hours with at least one period and valid form', () => {
+      component.form.disable();
+      component.periodesCalculHeuresStage = [
+        { id: 1, dateDebut: new Date('2023-01-01'), dateFin: new Date('2023-01-07'), nbHeuresJournalieres: 7 }
+      ];
+      component.checkPeriodesTravailValid();
+      expect(lastStatus).toBe(2);
+    });
+
+    it('should emit status 2 when regular hours without periods', () => {
+      component.form = fb.group({ horairesReguliers: [true], interruptionStage: [false] });
+      component.form.disable();
+      component.periodesCalculHeuresStage = [];
+      component.checkPeriodesTravailValid();
+      expect(lastStatus).toBe(2);
+    });
+
+    it('should invalidate tab after deleting last period', () => {
+      component.form.disable();
+      component.periodesCalculHeuresStage = [
+        { id: 42, dateDebut: new Date('2023-01-01'), dateFin: new Date('2023-01-07'), nbHeuresJournalieres: 7 }
+      ];
+      component.checkPeriodesTravailValid();
+      expect(lastStatus).toBe(2);
+
+      component.deletePeriodeStage(0);
+      expect(lastStatus).toBe(1);
+    });
   });
 });

--- a/src/frontend/src/app/components/convention/stage/stage.component.ts
+++ b/src/frontend/src/app/components/convention/stage/stage.component.ts
@@ -87,6 +87,7 @@ export class StageComponent implements OnInit {
   texteLimiteRenumeration: string = '';
 
   periodesInterruptionsValid:boolean = false;
+  periodesTravailValid: boolean = true;
   minDateDebutStage!: Date;
   maxDateDebutStage!: Date;
   minDateFinStage!: Date;
@@ -273,6 +274,9 @@ export class StageComponent implements OnInit {
         if (['interruptionStage','horairesReguliers','nbHeuresHebdo'].includes(key)){
           this.updateHeuresTravail();
         }
+        if (key === 'horairesReguliers') {
+          this.checkPeriodesTravailValid();
+        }
         // controle du chevauchement avant mise à jour
         if (['dateDebutStage','dateFinStage'].includes(key)) {
           if (this.isChevauchementAutorise()) {
@@ -388,7 +392,7 @@ export class StageComponent implements OnInit {
   validateForm() : void{
     let status = 0;
     if (Object.keys(this.form.value).some(k => !!this.form.value[k])) status = 1;
-    if ((this.form.valid || this.form.disabled) && this.periodesInterruptionsValid) status = 2;
+    if ((this.form.valid || this.form.disabled) && this.periodesInterruptionsValid && this.periodesTravailValid) status = 2;
     this.validated.emit(status);
   }
 
@@ -417,6 +421,15 @@ export class StageComponent implements OnInit {
 
   }
 
+  checkPeriodesTravailValid(): void {
+    if (this.form.get('horairesReguliers')?.value === false) {
+      this.periodesTravailValid = this.periodesCalculHeuresStage.length >= 1;
+    } else {
+      this.periodesTravailValid = true;
+    }
+    this.validateForm();
+  }
+
   setHorairesReguliersFormControls(event: any): void {
     this.toggleValidators(['nbHeuresHebdo'], event.value);
     if (!event.value) {
@@ -427,6 +440,7 @@ export class StageComponent implements OnInit {
       }
       this.periodesCalculHeuresStage = [];
       this.updateHeuresTravail();
+      this.checkPeriodesTravailValid();
     }
   }
 
@@ -521,6 +535,7 @@ export class StageComponent implements OnInit {
     this.periodeStageService.getByConvention(this.convention.id).subscribe((response: any) => {
       this.periodesCalculHeuresStage = response;
       this.updateHeuresTravail(true);
+      this.checkPeriodesTravailValid();
     });
   }
 
@@ -528,6 +543,7 @@ export class StageComponent implements OnInit {
     this.periodeStageService.getByConvention(this.convention.id).subscribe((response: any) => {
       this.periodesCalculHeuresStage = response;
       this.updateHeuresTravail();
+      this.checkPeriodesTravailValid();
     });
   }
 
@@ -539,6 +555,7 @@ export class StageComponent implements OnInit {
         periodesUpdated.splice(index, 1);
         this.periodesCalculHeuresStage = periodesUpdated;
         this.updateHeuresTravail();
+        this.checkPeriodesTravailValid();
       },
       error: (error) => {
         console.error("Error deleting period:", error);
@@ -586,6 +603,7 @@ export class StageComponent implements OnInit {
             // Handle the case where there are no periods
             this.periodesCalculHeuresStage = [];
             this.updateHeuresTravail();
+            this.checkPeriodesTravailValid();
           }
         } else {
           // For regular hours, just update the calculation

--- a/src/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/src/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -410,27 +410,43 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   changeAnnee(): void {
-    if (!this.appTable || !this.anneeEnCours){
+    if (!this.appTable || !this.anneeEnCours) {
       this.logError("Erreur lors du chargement du tableau");
-    }else if(this.appTable?.getFilters().annee?.value === "Toutes les années"){
-      delete this.appTable.filterValues['annee'];
-      this.appTable?.update();
-      this.countConvention();
-    } else {
+      return;
+    }
 
-      // Mettre à jour le filtre
-      this.appTable?.setFilter({
+    if (this.anneeEnCours.any) {
+      // Pas de filtre API pour "Toutes les années", mais on mémorise le choix pour le retour
+      delete this.appTable.filterValues['annee'];
+    } else {
+      this.appTable.setFilter({
         id: 'annee',
         type: 'text',
-        value: this.anneeEnCours.any ? "" : this.anneeEnCours.libelle,
+        value: this.anneeEnCours.libelle,
         specific: false,
         permanent: true
       });
-
-      // mise à jour du tableau
-      this.appTable.update();
-      this.countConvention();
     }
+
+    this.appTable.update();
+    this.countConvention();
+  }
+
+  private persistDashboardFilters(): void {
+    if (!this.appTable) {
+      return;
+    }
+    const filters = this.appTable.getFilterValues();
+    if (this.anneeEnCours?.any) {
+      filters['annee'] = {
+        id: 'annee',
+        type: 'text',
+        value: 'Toutes les années',
+        specific: false,
+        permanent: true
+      };
+    }
+    sessionStorage.setItem('dashboard-filters', JSON.stringify(filters));
   }
 
 
@@ -475,10 +491,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (this.typeDashboard !== 3 && this.appTable) {
       this.nbConventionsEnAttente = this.appTable.total;
     }
-    if (this.appTable) {
-      const filters = this.appTable?.getFilterValues();
-      sessionStorage.setItem('dashboard-filters', JSON.stringify(filters));
-    }
+    this.persistDashboardFilters();
   }
 
   goToConvention(id: number): void {
@@ -525,11 +538,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
       try {
         switch (key) {
           case 'annee':
-            if (filterValue.value) {
+            if (filterValue.value === 'Toutes les années' || filterValue.value === '') {
+              this.anneeEnCours = this.annees.find((a: any) => a.any === true);
+            } else if (filterValue.value) {
               this.anneeEnCours = this.annees.find((a: any) => a.libelle === filterValue.value);
-              if (this.anneeEnCours) {
-                this.changeAnnee();
-              }
+            }
+            if (this.anneeEnCours) {
+              this.changeAnnee();
             }
             break;
 
@@ -678,6 +693,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     sessionStorage.setItem('dashboard-paging', JSON.stringify({ page: this.appTable?.page, pageSize: this.appTable?.pageSize, sortColumn: this.appTable?.sortColumn, sortOrder: this.appTable?.sortOrder }));
-    sessionStorage.setItem('dashboard-filters', JSON.stringify(this.appTable?.getFilterValues()))
+    this.persistDashboardFilters();
   }
 }

--- a/src/frontend/src/app/components/eval-stage/eval-stage.component.ts
+++ b/src/frontend/src/app/components/eval-stage/eval-stage.component.ts
@@ -7,6 +7,7 @@ import { SortDirection } from "@angular/material/sort";
 import { TitleService } from "../../services/title.service";
 import { CentreGestionService } from "../../services/centre-gestion.service";
 import { UfrService } from "../../services/ufr.service";
+import { EtapeService } from "../../services/etape.service";
 import {EnvoiMailEnMasseEvalComponent} from "./envoi-mail-en-masse-eval/envoi-mail-en-masse-eval.component";
 import {MatDialog} from "@angular/material/dialog";
 import {ExportEvaluationComponent} from "./export-evaluation/export-evaluation.component";
@@ -46,6 +47,7 @@ export class EvalStageComponent implements OnInit, OnDestroy {
     private titleService: TitleService,
     private centreGestionService: CentreGestionService,
     private ufrService: UfrService,
+    private etapeService: EtapeService,
     private dialog: MatDialog,
     private questionsEvaluationService: QuestionsEvaluationService) {
   }
@@ -73,6 +75,7 @@ export class EvalStageComponent implements OnInit, OnDestroy {
         { id: 'id', libelle: 'N° de la convention', type: 'int' },
         { id: 'etudiant', libelle: 'Étudiant', specific: true },
         { id: 'ufr.id', libelle: 'Composante', type: 'list', options: [], keyLibelle: 'libelle', keyId: 'id', value: [], specific: true },
+        { id: 'etape.id', libelle: 'Étape', type: 'autocomplete', autocompleteService: this.etapeService, options: [], keyLibelle: 'libelle', keyId: 'id', value: [], specific: true, colSpan: 9 },
         { id: 'centreGestion.nomCentre', libelle: 'Centres de gestion', type: 'list', options: [], keyId: 'nomCentre', keyLibelle: 'nomCentre', colSpan: 6, infoBulleCentre: true },
         { id: 'stageTermine', libelle: 'N\'afficher que les stages terminés ?', type: 'boolean', specific: true }
       );

--- a/src/frontend/src/app/components/eval-stage/eval-stage.component.ts
+++ b/src/frontend/src/app/components/eval-stage/eval-stage.component.ts
@@ -178,7 +178,14 @@ export class EvalStageComponent implements OnInit, OnDestroy {
     const normalized = this.normalizeExportColumns(this.exportColumns);
     this.dialog.open(ExportEvaluationComponent, {
       width: '800px',
-      data: { sheets:normalized.sheets,rows:this.appTable?.data }
+      data: {
+        sheets: normalized.sheets,
+        rows: this.appTable?.data,
+        total: this.appTable?.total,
+        sortColumn: this.sortColumn,
+        sortOrder: this.sortDirection,
+        filters: JSON.stringify(this.appTable?.filterValuesToSend ?? {}),
+      }
     });
   }
 

--- a/src/frontend/src/app/components/eval-stage/export-evaluation/export-evaluation.component.html
+++ b/src/frontend/src/app/components/eval-stage/export-evaluation/export-evaluation.component.html
@@ -174,9 +174,15 @@
       </ng-container>
 
       <div class="actions" role="group" aria-label="Actions principales">
+        <div *ngIf="exporting" class="export-progress" aria-live="polite">
+          <mat-spinner diameter="24"></mat-spinner>
+          <span>Export en cours…</span>
+        </div>
+
         <button class="cancel-button" mat-flat-button
                 type="button"
                 (click)="cancel()"
+                [disabled]="exporting"
                 aria-label="Annuler et fermer">
           Annuler
         </button>
@@ -187,7 +193,7 @@
               [tabindex]="form.valid ? -1 : 0">
           <button class="valid-button" mat-flat-button
                   type="button"
-                  [disabled]="!form.valid"
+                  [disabled]="!form.valid || exporting"
                   (click)="confirm()"
                   aria-label="Valider la sélection et exporter">
             Valider

--- a/src/frontend/src/app/components/eval-stage/export-evaluation/export-evaluation.component.html
+++ b/src/frontend/src/app/components/eval-stage/export-evaluation/export-evaluation.component.html
@@ -7,6 +7,18 @@
     <div class="column-selector-dialog">
       <!-- Choix type fiche -->
       <div class="type-eval-form" [formGroup]="form">
+        <div class="radio-block export-scope-block" role="group" aria-label="Périmètre d'export">
+          <label class="block-label">Périmètre d'export : </label>
+          <mat-radio-group [(ngModel)]="exportScope" [ngModelOptions]="{standalone: true}">
+            <mat-radio-button value="filtered">
+              Tout le résultat filtré ({{ data.total ?? 0 }} évaluation(s))
+            </mat-radio-button>
+            <mat-radio-button value="page">
+              Page courante uniquement ({{ data.rows?.length ?? 0 }} évaluation(s))
+            </mat-radio-button>
+          </mat-radio-group>
+        </div>
+
         <div class="radio-block" role="group" aria-label="Choix du types d'évaluation">
           <label class="block-label">Types d'évaluation : </label>
           <mat-radio-group formControlName="typeFiche">

--- a/src/frontend/src/app/components/eval-stage/export-evaluation/export-evaluation.component.scss
+++ b/src/frontend/src/app/components/eval-stage/export-evaluation/export-evaluation.component.scss
@@ -274,6 +274,15 @@
   flex-wrap: wrap;
 }
 
+.export-progress {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-right: auto;
+  color: #555;
+  font-size: 0.9rem;
+}
+
 /* Cible aussi le bouton Valider, encapsulé dans un <span> pour le tooltip,
    afin que les deux boutons aient exactement la même taille. */
 .actions .cancel-button,

--- a/src/frontend/src/app/components/eval-stage/export-evaluation/export-evaluation.component.ts
+++ b/src/frontend/src/app/components/eval-stage/export-evaluation/export-evaluation.component.ts
@@ -4,6 +4,7 @@ import {FormBuilder, FormGroup, Validators} from "@angular/forms";
 import {EvaluationService} from "../../../services/evaluation.service";
 import * as FileSaver from "file-saver";
 import {CdkDragDrop, moveItemInArray} from "@angular/cdk/drag-drop";
+import {ExcelExportEval} from "../../../models/excel-export-eval.model";
 
 type TypeFiche = 0 | 1 | 2 | 3; // 0 = étudiant, 1 = enseignant référent, 2 = tuteur pro, 3 = tous
 
@@ -24,10 +25,18 @@ export class ExportEvaluationComponent {
   selectedAvailableKeys = new Set<string>();
   selectedChosenKeys = new Set<string>();
 
+  /** 'page' = page courante, 'filtered' = tout le résultat filtré */
+  exportScope: 'page' | 'filtered' = 'filtered';
+
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: {
       sheets: any[];
-      rows: any[] },
+      rows: any[];
+      total?: number;
+      sortColumn?: string;
+      sortOrder?: string;
+      filters?: string;
+    },
     public dialogRef: MatDialogRef<ExportEvaluationComponent>,
     private readonly fb: FormBuilder,
     private readonly evaluationService : EvaluationService,
@@ -49,15 +58,30 @@ export class ExportEvaluationComponent {
 
 // composant
   confirm() {
-    let SelectedColumns: string[] =  this.getSelectedColumnKeys(this.form.value.typeFiche);
+    const selectedColumns: string[] = this.getSelectedColumnKeys(this.form.value.typeFiche);
+    const typeFiche = this.form.value.typeFiche;
 
-    this.evaluationService
-      .getExportExcel(this.data.rows.map(r => r.id), this.form.value.typeFiche, SelectedColumns)
-      .subscribe((res) => {
-        const blob = res.body!;
-        FileSaver.saveAs(blob,'export_' + Date.now() + '.xlsx');
-        this.dialogRef.close();
-      });
+    let payload: ExcelExportEval = {
+      typeFiche,
+      ...(selectedColumns.length ? { colonnes: selectedColumns } : {})
+    };
+
+    if (this.exportScope === 'page') {
+      payload = { ...payload, idConventions: this.data.rows.map(r => r.id) };
+    } else {
+      payload = {
+        ...payload,
+        filters: this.data.filters ?? '{}',
+        predicate: this.data.sortColumn ?? 'id',
+        sortOrder: this.data.sortOrder ?? 'desc',
+      };
+    }
+
+    this.evaluationService.getExportExcel(payload).subscribe((res) => {
+      const blob = res.body!;
+      FileSaver.saveAs(blob, 'export_' + Date.now() + '.xlsx');
+      this.dialogRef.close();
+    });
   }
 
 

--- a/src/frontend/src/app/components/eval-stage/export-evaluation/export-evaluation.component.ts
+++ b/src/frontend/src/app/components/eval-stage/export-evaluation/export-evaluation.component.ts
@@ -2,9 +2,11 @@ import {Component, Inject} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef} from "@angular/material/dialog";
 import {FormBuilder, FormGroup, Validators} from "@angular/forms";
 import {EvaluationService} from "../../../services/evaluation.service";
+import {MessageService} from "../../../services/message.service";
 import * as FileSaver from "file-saver";
 import {CdkDragDrop, moveItemInArray} from "@angular/cdk/drag-drop";
 import {ExcelExportEval} from "../../../models/excel-export-eval.model";
+import {finalize} from "rxjs";
 
 type TypeFiche = 0 | 1 | 2 | 3; // 0 = étudiant, 1 = enseignant référent, 2 = tuteur pro, 3 = tous
 
@@ -28,6 +30,8 @@ export class ExportEvaluationComponent {
   /** 'page' = page courante, 'filtered' = tout le résultat filtré */
   exportScope: 'page' | 'filtered' = 'filtered';
 
+  exporting = false;
+
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: {
       sheets: any[];
@@ -40,6 +44,7 @@ export class ExportEvaluationComponent {
     public dialogRef: MatDialogRef<ExportEvaluationComponent>,
     private readonly fb: FormBuilder,
     private readonly evaluationService : EvaluationService,
+    private readonly messageService: MessageService,
   ) {
     this.form = this.fb.group({
       typeFiche: [null as TypeFiche | null, Validators.required],
@@ -58,6 +63,8 @@ export class ExportEvaluationComponent {
 
 // composant
   confirm() {
+    if (this.exporting) return;
+
     const selectedColumns: string[] = this.getSelectedColumnKeys(this.form.value.typeFiche);
     const typeFiche = this.form.value.typeFiche;
 
@@ -77,10 +84,18 @@ export class ExportEvaluationComponent {
       };
     }
 
-    this.evaluationService.getExportExcel(payload).subscribe((res) => {
-      const blob = res.body!;
-      FileSaver.saveAs(blob, 'export_' + Date.now() + '.xlsx');
-      this.dialogRef.close();
+    this.exporting = true;
+    this.evaluationService.getExportExcel(payload).pipe(
+      finalize(() => { this.exporting = false; })
+    ).subscribe({
+      next: (res) => {
+        const blob = res.body!;
+        FileSaver.saveAs(blob, 'export_' + Date.now() + '.xlsx');
+        this.dialogRef.close();
+      },
+      error: () => {
+        this.messageService.setError('Erreur lors de la génération de l\'export Excel.');
+      }
     });
   }
 
@@ -216,7 +231,7 @@ export class ExportEvaluationComponent {
   }
 
   get isLocked(): boolean {
-    return !(this.form?.valid);
+    return !(this.form?.valid) || this.exporting;
   }
 
   getFilteredColumns(t: TypeFiche): {

--- a/src/frontend/src/app/components/gestion-etab-accueil/gestion-etab-accueil.component.html
+++ b/src/frontend/src/app/components/gestion-etab-accueil/gestion-etab-accueil.component.html
@@ -1,6 +1,6 @@
 <mat-tab-group #tabs (selectedTabChange)="tabChanged($event)">
   <mat-tab label="Liste">
-    <div class="sirene-info-box" *ngIf="isSireneAcitve">
+    <div class="sirene-info-box" *ngIf="isSireneActive">
       <div class="sirene-info-title">
         <mat-icon aria-hidden="true">info</mat-icon>
         <span class="m-2">La recherche via l’API Sirene est déclenchée uniquement si :</span>

--- a/src/frontend/src/app/components/gestion-etab-accueil/gestion-etab-accueil.component.html
+++ b/src/frontend/src/app/components/gestion-etab-accueil/gestion-etab-accueil.component.html
@@ -3,15 +3,16 @@
     <div class="sirene-info-box" *ngIf="isSireneActive">
       <div class="sirene-info-title">
         <mat-icon aria-hidden="true">info</mat-icon>
-        <span class="m-2">La recherche via l’API Sirene est déclenchée uniquement si :</span>
+        <span class="m-2">La recherche de l'établissement se fait via la base de <a href="https://annuaire-entreprises.data.gouv.fr/">l'annuaire national des entreprises</a>. La recherche via l’API Sirene est déclenchée uniquement si le nombre de résultats locaux est <strong>inférieur à {{nbMinResultats}}</strong>, et si :</span>
       </div>
       <div class="sirene-info-details">
         <ul>
-          <li>au moins <strong>2 champs de filtre</strong> sont remplis</li>
-          <li>le nombre de résultats est <strong>inférieur à {{nbMinResultats}}</strong></li>
+          <li>au moins <strong>2 champs de recherche</strong> sont remplis (par ex : Raison sociale + Commune)</li>
           <li>ou une <strong>recherche directe par SIRET</strong> est effectuée</li>
+          <li>le filtre Pays n’est pas utilisé, <strong>ou</strong> la <strong>France</strong> fait partie des pays sélectionnés</li>
         </ul>
       </div>
+      En cas d’absence dans la liste, contactez votre gestionnaire de stage.
     </div>
     <app-table [service]="structureService" [columns]="columns" [sortColumn]="sortColumn" [filters]="filters" [exportColumns]="exportColumns"
                matSort [matSortActive]="sortColumn" [matSortDirection]="'asc'"

--- a/src/frontend/src/app/components/gestion-etab-accueil/gestion-etab-accueil.component.ts
+++ b/src/frontend/src/app/components/gestion-etab-accueil/gestion-etab-accueil.component.ts
@@ -56,7 +56,7 @@ export class GestionEtabAccueilComponent implements OnInit {
 
   contacts:any[] = [];
 
-  isSireneAcitve: boolean = false;
+  isSireneActive: boolean = false;
   nbMinResultats: number = 0;
 
   @ViewChild(TableComponent) appTable: TableComponent | undefined;
@@ -118,7 +118,7 @@ export class GestionEtabAccueilComponent implements OnInit {
       this.civilites = response.data;
     });
     this.structureService.getSireneInfo().subscribe((response: any) => {
-      this.isSireneAcitve = response.isApiSireneActive;
+      this.isSireneActive = response.isApiSireneActive;
       this.nbMinResultats = response.nombreResultats;
     });
   }

--- a/src/frontend/src/app/models/excel-export-eval.model.ts
+++ b/src/frontend/src/app/models/excel-export-eval.model.ts
@@ -1,5 +1,8 @@
 export interface ExcelExportEval {
-  idConventions: number[];
+  idConventions?: number[];
   typeFiche: number;       // 0,1,2,3
   colonnes?: string[];     // optionnel
+  filters?: string;        // export complet filtré
+  predicate?: string;
+  sortOrder?: string;
 }

--- a/src/frontend/src/app/services/evaluation.service.ts
+++ b/src/frontend/src/app/services/evaluation.service.ts
@@ -11,19 +11,11 @@ export class EvaluationService {
 
   constructor(private readonly http: HttpClient) { }
 
-  getExportExcel(idConventions: number[], typeFiche: number, columns?: string[]): Observable<any> {
-    let body:ExcelExportEval = {
-      idConventions,
-      typeFiche,
-      ...(columns?.length ? { colonnes: columns } : {})
-    };
-
+  getExportExcel(payload: ExcelExportEval): Observable<any> {
     return this.http.post<Blob>(`${environment.apiUrl}/evaluations/excel`,
-      body,
+      payload,
       {responseType: 'blob' as 'json', observe: 'response'}
     );
   }
-
-
 
 }

--- a/src/main/java/org/esup_portail/esup_stage/controller/ConventionController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/ConventionController.java
@@ -111,6 +111,8 @@ public class  ConventionController {
     @Autowired
     MailerService mailerService;
 
+    @Autowired
+    PeriodeStageJpaRepository periodeStageJpaRepository;
 
 
     @GetMapping
@@ -328,6 +330,9 @@ public class  ConventionController {
 
         // Contrôle chevauchement de dates
         checkChevauchement(convention,utilisateur);
+
+        // Contrôle des périodes de travail pour horaires irréguliers
+        checkPeriodesTravail(convention);
 
         convention.setValidationCreation(true);
         convention.setDateValidationCreation(new Date());
@@ -1040,6 +1045,18 @@ public class  ConventionController {
                     HttpStatus.BAD_REQUEST,
                     "Les dates de début et fin de stage se chevauchent avec une de vos conventions"
             );
+        }
+    }
+
+    private void checkPeriodesTravail(Convention convention) {
+        if (Boolean.FALSE.equals(convention.getHorairesReguliers())) {
+            List<PeriodeStage> periodes = periodeStageJpaRepository.findByConvention(convention);
+            if (periodes == null || periodes.isEmpty()) {
+                throw new AppException(
+                        HttpStatus.BAD_REQUEST,
+                        "Au moins une période de travail est requise pour les horaires irréguliers"
+                );
+            }
         }
     }
 

--- a/src/main/java/org/esup_portail/esup_stage/controller/EvaluationController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/EvaluationController.java
@@ -9,6 +9,7 @@ import org.esup_portail.esup_stage.enums.DroitEnum;
 import org.esup_portail.esup_stage.exception.AppException;
 import org.esup_portail.esup_stage.model.Convention;
 import org.esup_portail.esup_stage.repository.ConventionJpaRepository;
+import org.esup_portail.esup_stage.repository.ConventionRepository;
 import org.esup_portail.esup_stage.repository.QuestionSupplementaireJpaRepository;
 import org.esup_portail.esup_stage.security.interceptor.Secure;
 import org.esup_portail.esup_stage.service.evaluation.EvaluationService;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @ApiController
 @RequestMapping("/evaluations")
@@ -28,6 +30,9 @@ public class EvaluationController {
 
     @Autowired
     private ConventionJpaRepository conventionJpaRepository;
+
+    @Autowired
+    private ConventionRepository conventionRepository;
 
     @Autowired
     private QuestionSupplementaireJpaRepository questionSupplementaireJpaRepository;
@@ -55,9 +60,27 @@ public class EvaluationController {
     @PostMapping(value = "/excel", produces = "application/vnd.ms-excel")
     @Secure(fonctions = {AppFonctionEnum.CONVENTION}, droits = {DroitEnum.LECTURE})
     public ResponseEntity<byte[]> exportExcel(@RequestBody ExcelExportEvalDto excelExportEvalDto) {
-
-        byte[] bytes = evaluationService.getEvaluationToExcel(getEvalsFromConventions(excelExportEvalDto.getIdConventions()),excelExportEvalDto.getTypeFiche(),excelExportEvalDto.getColonnes());
+        List<Integer> idConventions = resolveConventionIds(excelExportEvalDto);
+        byte[] bytes = evaluationService.getEvaluationToExcel(
+                getEvalsFromConventions(idConventions),
+                excelExportEvalDto.getTypeFiche(),
+                excelExportEvalDto.getColonnes());
         return ResponseEntity.ok().body(bytes);
+    }
+
+    private List<Integer> resolveConventionIds(ExcelExportEvalDto dto) {
+        if (dto.getIdConventions() != null && !dto.getIdConventions().isEmpty()) {
+            return dto.getIdConventions();
+        }
+        if (dto.getFilters() != null && !dto.getFilters().isBlank()) {
+            String predicate = dto.getPredicate() != null && !dto.getPredicate().isBlank() ? dto.getPredicate() : "id";
+            String sortOrder = dto.getSortOrder() != null && !dto.getSortOrder().isBlank() ? dto.getSortOrder() : "desc";
+            return conventionRepository.findPaginated(1, 0, predicate, sortOrder, dto.getFilters())
+                    .stream()
+                    .map(Convention::getId)
+                    .collect(Collectors.toList());
+        }
+        throw new AppException(HttpStatus.BAD_REQUEST, "Aucune convention à exporter : fournir idConventions ou filters");
     }
 
     /* ===================== Helpers ===================== */

--- a/src/main/java/org/esup_portail/esup_stage/controller/ReponseEvaluationController.java
+++ b/src/main/java/org/esup_portail/esup_stage/controller/ReponseEvaluationController.java
@@ -88,6 +88,7 @@ public class ReponseEvaluationController {
             logger.debug("error envoie mail");
         }
         evaluationService.setReponseEvaluationEtudiantData(reponseEvaluation, reponseEtudiantFormDto);
+        reponseEvaluation.setSchemaVersion(2);
         return reponseEvaluationJpaRepository.saveAndFlush(reponseEvaluation);
     }
 
@@ -110,6 +111,7 @@ public class ReponseEvaluationController {
             mailerService.sendValidationMail(convention, null, utilisateur, TemplateMail.CODE_EVAL_ETU_REMPLIE, sendMailEtudiant, sendMailEnseignant, sendMailGestionnaire, sendMailRespGestionnaire);
         }
         evaluationService.setReponseEvaluationEtudiantData(reponseEvaluation, reponseEtudiantFormDto);
+        reponseEvaluation.setSchemaVersion(2);
         return reponseEvaluationJpaRepository.saveAndFlush(reponseEvaluation);
     }
 

--- a/src/main/java/org/esup_portail/esup_stage/dto/EvaluationDto.java
+++ b/src/main/java/org/esup_portail/esup_stage/dto/EvaluationDto.java
@@ -21,6 +21,7 @@ public class EvaluationDto {
     private CentreGestion centreGestion;
     private Etape etape;
     private String anneeUniversitaire;
+    private String origineStageLibelle;
     private FicheEvaluation ficheEvaluation;
     private ReponseEvaluation reponseEvaluation;
     private List<QuestionSupplementaire> questionSupplementaires;
@@ -35,6 +36,11 @@ public class EvaluationDto {
         this.centreGestion = convention.getCentreGestion();
         this.etape = convention.getEtape();
         this.anneeUniversitaire = convention.getAnnee();
+        if (convention.getOrigineStage() != null && convention.getOrigineStage().getLibelle() != null) {
+            this.origineStageLibelle = convention.getOrigineStage().getLibelle();
+        } else if (convention.getNomenclature() != null && convention.getNomenclature().getOrigineStage() != null) {
+            this.origineStageLibelle = convention.getNomenclature().getOrigineStage();
+        }
         this.ficheEvaluation = convention.getCentreGestion().getFicheEvaluation();
         this.reponseEvaluation = convention.getReponseEvaluation();
         this.questionSupplementaires = questionSupplementaires;

--- a/src/main/java/org/esup_portail/esup_stage/dto/ExcelExportEvalDto.java
+++ b/src/main/java/org/esup_portail/esup_stage/dto/ExcelExportEvalDto.java
@@ -10,4 +10,8 @@ public class ExcelExportEvalDto {
     List<Integer> idConventions;
     Integer typeFiche;
     List<String> colonnes;
+    /** Filtres JSON (export complet filtré, alternative à idConventions) */
+    String filters;
+    String predicate;
+    String sortOrder;
 }

--- a/src/main/java/org/esup_portail/esup_stage/model/ReponseEvaluation.java
+++ b/src/main/java/org/esup_portail/esup_stage/model/ReponseEvaluation.java
@@ -39,6 +39,9 @@ public class ReponseEvaluation {
     @JsonView(Views.List.class)
     private Boolean impressionEntreprise;
 
+    /** 1 = format réponses pré-3.2.0 (ETUI7 ancien), 2 = format courant */
+    private Integer schemaVersion;
+
     private Integer reponseEnt1;
     @Lob
     private String reponseEnt1bis;

--- a/src/main/java/org/esup_portail/esup_stage/service/evaluation/EvaluationExcelExporter.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/evaluation/EvaluationExcelExporter.java
@@ -159,6 +159,40 @@ public class EvaluationExcelExporter {
         return Collections.emptyList();
     }
 
+    private List<String> qEtui7BisItems(String branch) {
+        QuestionEvaluation q = questionsByCode.get("ETUI7");
+        if (q == null || q.getParamsJson() == null || q.getParamsJson().isBlank()) {
+            return defaultEtui7BisItems(branch);
+        }
+        try {
+            Map<String, Object> m = mapper.readValue(q.getParamsJson(), new TypeReference<Map<String, Object>>() {});
+            Object branchObj = m.get(branch);
+            if (branchObj instanceof Map<?, ?> branchMap) {
+                Object items = branchMap.get("items");
+                if (items instanceof List<?> list && !list.isEmpty()) {
+                    return list.stream().map(String::valueOf).toList();
+                }
+            }
+        } catch (Exception ignored) {}
+        return defaultEtui7BisItems(branch);
+    }
+
+    private List<String> defaultEtui7BisItems(String branch) {
+        if ("oui".equals(branch)) {
+            return List.of(
+                    "Proposé par votre tuteur professionnel",
+                    "Proposé par votre tuteur enseignant",
+                    "Élaboré par vous-même",
+                    "Négocié entre les parties",
+                    "Autre"
+            );
+        }
+        return List.of(
+                "Je n'ai pas eu besoin d'aide",
+                "Je ne savais pas à qui m'adresser"
+        );
+    }
+
     private void createSheet(Workbook workbook, List<EvaluationDto> evaluations, ExportType type, String sheetName, List<String> columnFilter) {
         Sheet sheet = workbook.createSheet(sheetName);
 
@@ -384,7 +418,8 @@ public class EvaluationExcelExporter {
 
         switch (type) {
             case ETUDIANT:
-                return fiche.getValidationEtudiant() != null && fiche.getValidationEtudiant();
+                return fiche.getValidationEtudiant() != null && fiche.getValidationEtudiant()
+                        && Boolean.TRUE.equals(eval.getReponseEvaluation().getValidationEtudiant());
             case ENSEIGNANT:
                 return fiche.getValidationEnseignant() != null && fiche.getValidationEnseignant();
             case ENTREPRISE:
@@ -614,14 +649,14 @@ public class EvaluationExcelExporter {
         if (r == null) return "";
 
         switch (type) {
-            case ETUDIANT: return getEtudiantValue(code, r);
+            case ETUDIANT: return getEtudiantValue(code, eval, r);
             case ENSEIGNANT: return getEnseignantValue(code, r);
             case ENTREPRISE: return getEntrepriseValue(code, r);
             default: return "";
         }
     }
 
-    private Object getEtudiantValue(String code, ReponseEvaluation r) {
+    private Object getEtudiantValue(String code, EvaluationDto eval, ReponseEvaluation r) {
         return switch (code) {
             case "ETUI1" -> r.getReponseEtuI1();
             case "ETUI1bis" -> r.getReponseEtuI1bis();
@@ -631,7 +666,7 @@ public class EvaluationExcelExporter {
             case "ETUI4b" -> r.getReponseEtuI4b();
             case "ETUI4c" -> r.getReponseEtuI4c();
             case "ETUI4d" -> r.getReponseEtuI4d();
-            case "ETUI5" -> r.getReponseEtuI5();
+            case "ETUI5" -> resolveEtui5Value(eval, r);
             case "ETUI6" -> r.getReponseEtuI6();
             case "ETUI7" -> r.getReponseEtuI7();
             case "ETUI7_bis1" -> r.getReponseEtuI7bis1();
@@ -675,6 +710,20 @@ public class EvaluationExcelExporter {
             case "ETUIII16bis" -> r.getReponseEtuIII16bis();
             default -> "";
         };
+    }
+
+    private Object resolveEtui5Value(EvaluationDto eval, ReponseEvaluation r) {
+        if (r.getReponseEtuI5() != null) {
+            QuestionEvaluation question = questionsByCode.get("ETUI5");
+            if (question != null) {
+                String formatted = formatSingleChoice(question, r.getReponseEtuI5());
+                if (!formatted.isBlank()) {
+                    return formatted;
+                }
+            }
+            return r.getReponseEtuI5();
+        }
+        return eval.getOrigineStageLibelle() != null ? eval.getOrigineStageLibelle() : "";
     }
 
     private Object getEnseignantValue(String code, ReponseEvaluation r) {
@@ -779,7 +828,7 @@ public class EvaluationExcelExporter {
         }
 
         switch (type) {
-            case ETUDIANT -> colNum = fillEtudiantData(row, colNum, reponse, dataStyle);
+            case ETUDIANT -> colNum = fillEtudiantData(row, colNum, eval, reponse, dataStyle);
             case ENSEIGNANT -> colNum = fillEnseignantData(row, colNum, reponse, dataStyle);
             case ENTREPRISE -> colNum = fillEntrepriseData(row, colNum, reponse, dataStyle);
         }
@@ -813,7 +862,7 @@ public class EvaluationExcelExporter {
         }
     }
 
-    private int fillEtudiantData(Row row, int colNum, ReponseEvaluation r, CellStyle style) {
+    private int fillEtudiantData(Row row, int colNum, EvaluationDto eval, ReponseEvaluation r, CellStyle style) {
         createCell(row, colNum++, "ETUI1",  r.getReponseEtuI1(), style);
         createCell(row, colNum++, "ETUI1bis", r.getReponseEtuI1bis(), style);
         createCell(row, colNum++, "ETUI2",  r.getReponseEtuI2(), style);
@@ -822,7 +871,7 @@ public class EvaluationExcelExporter {
         createCell(row, colNum++, "ETUI4b", r.getReponseEtuI4b(), style);
         createCell(row, colNum++, "ETUI4c", r.getReponseEtuI4c(), style);
         createCell(row, colNum++, "ETUI4d", r.getReponseEtuI4d(), style);
-        createCell(row, colNum++, "ETUI5",  r.getReponseEtuI5(), style);
+        createCell(row, colNum++, "ETUI5",  getEtudiantValue("ETUI5", eval, r), style);
         createCell(row, colNum++, "ETUI6",  r.getReponseEtuI6(), style);
         createCell(row, colNum++, "ETUI7",  r.getReponseEtuI7(), style);
         createCell(row, colNum++, "ETUI7_bis1", r.getReponseEtuI7bis1(), style);
@@ -934,6 +983,11 @@ public class EvaluationExcelExporter {
 
         if (value == null) {
             cell.setCellValue("");
+            return;
+        }
+
+        if (value instanceof String) {
+            cell.setCellValue((String) value);
             return;
         }
 
@@ -1069,13 +1123,7 @@ public class EvaluationExcelExporter {
         if (schemaVersion < 2) {
             return index == 1 ? "Oui" : "Non";
         }
-        List<String> options = List.of(
-                "Proposé par votre tuteur professionnel",
-                "Proposé par votre tuteur enseignant",
-                "Élaboré par vous-même",
-                "Négocié entre les parties",
-                "Autre"
-        );
+        List<String> options = qEtui7BisItems("oui");
 
         if (index >= 0 && index < options.size()) {
             return options.get(index);
@@ -1090,10 +1138,7 @@ public class EvaluationExcelExporter {
         if (schemaVersion < 2) {
             return index == 1 ? "Oui" : "Non";
         }
-        List<String> options = List.of(
-                "Je n'ai pas eu besoin d'aide",
-                "Je ne savais pas à qui m'adresser"
-        );
+        List<String> options = qEtui7BisItems("non");
 
         if (index >= 0 && index < options.size()) {
             return options.get(index);

--- a/src/main/java/org/esup_portail/esup_stage/service/evaluation/EvaluationExcelExporter.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/evaluation/EvaluationExcelExporter.java
@@ -1119,12 +1119,13 @@ public class EvaluationExcelExporter {
     private String formatEtuI7Bis1(Object value, int schemaVersion) {
         if (!(value instanceof Integer)) return value != null ? value.toString() : "";
 
-        int index = (Integer) value;
+        // Ancien format : indices Oui/Non non réexploitables dans les colonnes « Si oui / Si non »
         if (schemaVersion < 2) {
-            return index == 1 ? "Oui" : "Non";
+            return "";
         }
-        List<String> options = qEtui7BisItems("oui");
 
+        int index = (Integer) value;
+        List<String> options = qEtui7BisItems("oui");
         if (index >= 0 && index < options.size()) {
             return options.get(index);
         }
@@ -1134,12 +1135,12 @@ public class EvaluationExcelExporter {
     private String formatEtuI7Bis2(Object value, int schemaVersion) {
         if (!(value instanceof Integer)) return value != null ? value.toString() : "";
 
-        int index = (Integer) value;
         if (schemaVersion < 2) {
-            return index == 1 ? "Oui" : "Non";
+            return "";
         }
-        List<String> options = qEtui7BisItems("non");
 
+        int index = (Integer) value;
+        List<String> options = qEtui7BisItems("non");
         if (index >= 0 && index < options.size()) {
             return options.get(index);
         }

--- a/src/main/java/org/esup_portail/esup_stage/service/evaluation/EvaluationExcelExporter.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/evaluation/EvaluationExcelExporter.java
@@ -31,6 +31,8 @@ public class EvaluationExcelExporter {
 
     private Map<String, QuestionEvaluation> questionsByCode;
     private final ObjectMapper mapper = new ObjectMapper();
+    /** Version du schéma de la réponse en cours d'export (ETUI7) */
+    private int exportSchemaVersion = 2;
     private static final List<String> LIKERT_5 = List.of("Excellent","Très bien","Bien","Satisfaisant","Insuffisant");
     private static final List<String> AGREEMENT_5 = List.of("Tout à fait d'accord","Plutôt d'accord","Sans avis","Plutôt pas d'accord","Pas du tout d'accord");
 
@@ -562,6 +564,7 @@ public class EvaluationExcelExporter {
 
     private void fillDataRow(Row row, EvaluationDto eval, ExportType type, CellStyle dataStyle, List<String> columnCodes) {
         ReponseEvaluation reponse = eval.getReponseEvaluation();
+        exportSchemaVersion = resolveSchemaVersion(reponse != null ? reponse.getSchemaVersion() : null);
 
         // Si pas de filtrage, utiliser l'ancienne méthode
         if (columnCodes == null || columnCodes.isEmpty()) {
@@ -770,6 +773,7 @@ public class EvaluationExcelExporter {
         createCell(row, colNum++, eval.getAnneeUniversitaire(), dataStyle);
 
         ReponseEvaluation reponse = eval.getReponseEvaluation();
+        exportSchemaVersion = resolveSchemaVersion(reponse != null ? reponse.getSchemaVersion() : null);
         if (reponse == null) {
             return;
         }
@@ -1042,11 +1046,11 @@ public class EvaluationExcelExporter {
     private String formatSpecialCaseValue(String code, Object value) {
         switch (code) {
             case "ETUI7_bis1":
-                return formatEtuI7Bis1(value);
+                return formatEtuI7Bis1(value, exportSchemaVersion);
             case "ETUI7_bis2":
-                return formatEtuI7Bis2(value);
+                return formatEtuI7Bis2(value, exportSchemaVersion);
             case "ETUII5a":
-                return formatEtuII5a(value);
+                return formatEtuII5a(value, exportSchemaVersion);
             case "ETUII5b":
                 return formatEtuII5b(value);
             default:
@@ -1054,10 +1058,17 @@ public class EvaluationExcelExporter {
         }
     }
 
-    private String formatEtuI7Bis1(Object value) {
+    private int resolveSchemaVersion(Integer schemaVersion) {
+        return schemaVersion == null || schemaVersion < 2 ? 1 : schemaVersion;
+    }
+
+    private String formatEtuI7Bis1(Object value, int schemaVersion) {
         if (!(value instanceof Integer)) return value != null ? value.toString() : "";
 
         int index = (Integer) value;
+        if (schemaVersion < 2) {
+            return index == 1 ? "Oui" : "Non";
+        }
         List<String> options = List.of(
                 "Proposé par votre tuteur professionnel",
                 "Proposé par votre tuteur enseignant",
@@ -1072,10 +1083,13 @@ public class EvaluationExcelExporter {
         return "";
     }
 
-    private String formatEtuI7Bis2(Object value) {
+    private String formatEtuI7Bis2(Object value, int schemaVersion) {
         if (!(value instanceof Integer)) return value != null ? value.toString() : "";
 
         int index = (Integer) value;
+        if (schemaVersion < 2) {
+            return index == 1 ? "Oui" : "Non";
+        }
         List<String> options = List.of(
                 "Je n'ai pas eu besoin d'aide",
                 "Je ne savais pas à qui m'adresser"
@@ -1087,8 +1101,16 @@ public class EvaluationExcelExporter {
         return "";
     }
 
-    private String formatEtuII5a(Object value) {
-        return value != null ? value.toString() : "";
+    private String formatEtuII5a(Object value, int schemaVersion) {
+        if (!(value instanceof Integer)) return value != null ? value.toString() : "";
+        int index = (Integer) value;
+        List<String> options = schemaVersion < 2
+                ? List.of("Très importantes", "Importantes", "Peu importantes")
+                : List.of("Technique", "Organisationnelle", "Communication");
+        if (index >= 0 && index < options.size()) {
+            return options.get(index);
+        }
+        return "";
     }
 
     private String formatEtuII5b(Object value) {

--- a/src/main/java/org/esup_portail/esup_stage/service/evaluation/EvaluationService.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/evaluation/EvaluationService.java
@@ -297,6 +297,7 @@ public class EvaluationService {
         reponseEvaluation.setReponseEvaluationId(reponseEvaluationId);
         reponseEvaluation.setFicheEvaluation(ficheEvaluation);
         reponseEvaluation.setConvention(convention);
+        reponseEvaluation.setSchemaVersion(2);
 
         return reponseEvaluation;
     }

--- a/src/main/java/org/esup_portail/esup_stage/service/impression/context/ImpressionContext.java
+++ b/src/main/java/org/esup_portail/esup_stage/service/impression/context/ImpressionContext.java
@@ -664,10 +664,13 @@ public class ImpressionContext {
         @Lob
         private String reponseEnsII11;
 
+        private Integer schemaVersion;
+
         public ReponseEvaluationContext(ReponseEvaluation reponseEvaluation) {
             if (reponseEvaluation == null) {
                 return;
             }
+            this.schemaVersion = reponseEvaluation.getSchemaVersion() != null && reponseEvaluation.getSchemaVersion() >= 2 ? 2 : 1;
             this.reponseEnt1 = reponseEvaluation.getReponseEnt1();
             this.reponseEnt1bis = reponseEvaluation.getReponseEnt1bis();
             this.reponseEnt2 = reponseEvaluation.getReponseEnt2();
@@ -967,11 +970,13 @@ public class ImpressionContext {
         private String code;
         private String texte;
         private TypeQuestionEvaluation type;
+        private String paramsJson;
 
         public QuestionEvaluationContext(QuestionEvaluation questionEvaluation) {
             this.code = questionEvaluation.getCode();
             this.texte = questionEvaluation.getTexte();
             this.type = questionEvaluation.getType();
+            this.paramsJson = questionEvaluation.getParamsJson();
         }
     }
 }

--- a/src/main/resources/db/changelog/3.2.4-reponse-evaluation-schema-version.yaml
+++ b/src/main/resources/db/changelog/3.2.4-reponse-evaluation-schema-version.yaml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.2.4-reponse-evaluation-schema-version
+      author: esup
+      changes:
+        - addColumn:
+            tableName: ReponseEvaluation
+            columns:
+              - column:
+                  name: schemaVersion
+                  type: INT
+                  defaultValueNumeric: 1
+        - update:
+            tableName: ReponseEvaluation
+            columns:
+              - column:
+                  name: schemaVersion
+                  valueNumeric: 1
+            where: schemaVersion IS NULL

--- a/src/main/resources/db/changelog/3.2.4-reponse-evaluation-schema-version.yaml
+++ b/src/main/resources/db/changelog/3.2.4-reponse-evaluation-schema-version.yaml
@@ -17,3 +17,19 @@ databaseChangeLog:
                   name: schemaVersion
                   valueNumeric: 1
             where: schemaVersion IS NULL
+
+  # ETUI7 utilise bis1/bis2 dédiés : les flags bis génériques ne doivent plus activer un contrôle fantôme
+  - changeSet:
+      id: 3.2.4-etui7-clear-generic-bis-flags
+      author: esup
+      changes:
+        - update:
+            tableName: QuestionEvaluation
+            columns:
+              - column:
+                  name: bisQuestionTrue
+                  valueBoolean: false
+              - column:
+                  name: bisQuestionFalse
+                  valueBoolean: false
+            where: "codeQuestionEvaluation = 'ETUI7'"

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -336,3 +336,6 @@ databaseChangeLog:
   - include:
         file: 3.2.0-fix-nomenclatures-modifiable-par-defaut.yaml
         relativeToChangelogFile: true
+  - include:
+        file: 3.2.4-reponse-evaluation-schema-version.yaml
+        relativeToChangelogFile: true

--- a/src/main/resources/templates/template_evaluation_etu.html
+++ b/src/main/resources/templates/template_evaluation_etu.html
@@ -132,31 +132,49 @@
             <#if reponse.reponseEtuI7 == false>Non</#if>
           </#if>
         </p>
-        <#-- Détails si oui : on utilise les champs *bis* -->
-        <#if reponse.reponseEtuI7?? && reponse.reponseEtuI7 == true>
-          <ul>
-            <#if reponse.reponseEtuI7bis1??>
-              <li>Par votre réseau personnel :
-                <#if reponse.reponseEtuI7bis1 == 0>Non</#if>
-                <#if reponse.reponseEtuI7bis1 == 1>Oui</#if>
-              </li>
-            </#if>
-            <#if reponse.reponseEtuI7bis1a??>
-              <li>Au sein de votre formation :
-                <#if reponse.reponseEtuI7bis1a == 0>Non</#if>
-                <#if reponse.reponseEtuI7bis1a == 1>Oui</#if>
-              </li>
-            </#if>
-            <#if reponse.reponseEtuI7bis1b?? && reponse.reponseEtuI7bis1b != "">
-              <li>Autre : ${reponse.reponseEtuI7bis1b}</li>
-            </#if>
-            <#if reponse.reponseEtuI7bis2??>
-              <li>Service(s) d'accompagnement (BAIP, SUIO-IP, etc.) :
-                <#if reponse.reponseEtuI7bis2 == 0>Non</#if>
-                <#if reponse.reponseEtuI7bis2 == 1>Oui</#if>
-              </li>
-            </#if>
-          </ul>
+        <#assign etui7Schema = (reponse.schemaVersion?? && reponse.schemaVersion gte 2) ? 2 : 1>
+        <#if etui7Schema gte 2>
+          <#-- Format >= 3.2.0 : choix unique si oui / si non -->
+          <#if reponse.reponseEtuI7?? && reponse.reponseEtuI7 == true && reponse.reponseEtuI7bis1??>
+            <#assign etui7Q = questionEvaluations?filter(q -> q.code == "ETUI7")[0]>
+            <#assign etui7OuiOptions = ["Proposé par votre tuteur professionnel", "Proposé par votre tuteur enseignant", "Élaboré par vous-même", "Négocié entre les parties", "Autre"]>
+            <p>Si oui, par qui ? :
+              <#if reponse.reponseEtuI7bis1 gte 0 && reponse.reponseEtuI7bis1 < etui7OuiOptions?size>${etui7OuiOptions[reponse.reponseEtuI7bis1]}</#if>
+            </p>
+          </#if>
+          <#if reponse.reponseEtuI7?? && reponse.reponseEtuI7 == false && reponse.reponseEtuI7bis2??>
+            <#assign etui7NonOptions = ["Je n'ai pas eu besoin d'aide", "Je ne savais pas à qui m'adresser"]>
+            <p>Si non, pourquoi ? :
+              <#if reponse.reponseEtuI7bis2 gte 0 && reponse.reponseEtuI7bis2 < etui7NonOptions?size>${etui7NonOptions[reponse.reponseEtuI7bis2]}</#if>
+            </p>
+          </#if>
+        <#else>
+          <#-- Format historique <= 3.1.x -->
+          <#if reponse.reponseEtuI7?? && reponse.reponseEtuI7 == true>
+            <ul>
+              <#if reponse.reponseEtuI7bis1??>
+                <li>Par votre réseau personnel :
+                  <#if reponse.reponseEtuI7bis1 == 0>Non</#if>
+                  <#if reponse.reponseEtuI7bis1 == 1>Oui</#if>
+                </li>
+              </#if>
+              <#if reponse.reponseEtuI7bis1a??>
+                <li>Au sein de votre formation :
+                  <#if reponse.reponseEtuI7bis1a == 0>Non</#if>
+                  <#if reponse.reponseEtuI7bis1a == 1>Oui</#if>
+                </li>
+              </#if>
+              <#if reponse.reponseEtuI7bis1b?? && reponse.reponseEtuI7bis1b != "">
+                <li>Autre : ${reponse.reponseEtuI7bis1b}</li>
+              </#if>
+              <#if reponse.reponseEtuI7bis2??>
+                <li>Service(s) d'accompagnement (BAIP, SUIO-IP, etc.) :
+                  <#if reponse.reponseEtuI7bis2 == 0>Non</#if>
+                  <#if reponse.reponseEtuI7bis2 == 1>Oui</#if>
+                </li>
+              </#if>
+            </ul>
+          </#if>
         </#if>
       </div>
     </#if>
@@ -178,14 +196,16 @@
   <div>
     <h3>II. Pendant le stage</h3>
 
-    <#-- II1 : moment de présentation des modalités (pas de code en base dans le changelog fourni) -->
+    <#-- II1 : Accueil (ETUII1) -->
     <#if ficheEvaluation.questionEtuII1>
       <div class="evaluation-item">
-        <p><strong>- Quand ces modalités vous ont-elles été présentées ?</strong>
+        <p><strong>- ${questionEvaluations?filter(q -> q.code == "ETUII1")[0].texte}</strong>
           <#if reponse.reponseEtuII1??>
-            <#if reponse.reponseEtuII1 == 0>Avant le début du stage</#if>
-            <#if reponse.reponseEtuII1 == 1>Pendant le stage</#if>
-            <#if reponse.reponseEtuII1 == 2>Jamais</#if>
+            <#if reponse.reponseEtuII1 == 0>Excellent</#if>
+            <#if reponse.reponseEtuII1 == 1>Très bien</#if>
+            <#if reponse.reponseEtuII1 == 2>Bien</#if>
+            <#if reponse.reponseEtuII1 == 3>Satisfaisant</#if>
+            <#if reponse.reponseEtuII1 == 4>Insuffisant</#if>
           </#if>
         </p>
         <#if reponse.reponseEtuII1bis?? && reponse.reponseEtuII1bis != "">
@@ -194,10 +214,10 @@
       </div>
     </#if>
 
-    <#-- II2 : Accueil -->
+    <#-- II2 : Encadrement (ETUII2) -->
     <#if ficheEvaluation.questionEtuII2>
       <div class="evaluation-item">
-        <p><strong>- ${questionEvaluations?filter(q -> q.code == "ETUII1")[0].texte}</strong>
+        <p><strong>- ${questionEvaluations?filter(q -> q.code == "ETUII2")[0].texte}</strong>
           <#if reponse.reponseEtuII2??>
             <#if reponse.reponseEtuII2 == 0>Excellent</#if>
             <#if reponse.reponseEtuII2 == 1>Très bien</#if>
@@ -212,10 +232,10 @@
       </div>
     </#if>
 
-    <#-- II3 : Encadrement -->
+    <#-- II3 : Adaptation (ETUII3) -->
     <#if ficheEvaluation.questionEtuII3>
       <div class="evaluation-item">
-        <p><strong>- ${questionEvaluations?filter(q -> q.code == "ETUII2")[0].texte}</strong>
+        <p><strong>- ${questionEvaluations?filter(q -> q.code == "ETUII3")[0].texte}</strong>
           <#if reponse.reponseEtuII3??>
             <#if reponse.reponseEtuII3 == 0>Excellent</#if>
             <#if reponse.reponseEtuII3 == 1>Très bien</#if>
@@ -230,45 +250,54 @@
       </div>
     </#if>
 
-    <#-- II4 : Adaptation -->
+    <#-- II4 : Conditions matérielles (ETUII4) -->
     <#if ficheEvaluation.questionEtuII4>
       <div class="evaluation-item">
-        <p><strong>- ${questionEvaluations?filter(q -> q.code == "ETUII3")[0].texte}</strong>
+        <p><strong>- ${questionEvaluations?filter(q -> q.code == "ETUII4")[0].texte}</strong>
           <#if reponse.reponseEtuII4??>
-            <#if reponse.reponseEtuII4 == 0>Excellent</#if>
-            <#if reponse.reponseEtuII4 == 1>Très bien</#if>
-            <#if reponse.reponseEtuII4 == 2>Bien</#if>
-            <#if reponse.reponseEtuII4 == 3>Satisfaisant</#if>
-            <#if reponse.reponseEtuII4 == 4>Insuffisant</#if>
+            <#if reponse.reponseEtuII4 == 0>Tout à fait d'accord</#if>
+            <#if reponse.reponseEtuII4 == 1>Plutôt d'accord</#if>
+            <#if reponse.reponseEtuII4 == 2>Sans avis</#if>
+            <#if reponse.reponseEtuII4 == 3>Plutôt pas d'accord</#if>
+            <#if reponse.reponseEtuII4 == 4>Pas du tout d'accord</#if>
           </#if>
         </p>
       </div>
     </#if>
 
-    <#-- II5/II5a/II5b : Conditions matérielles -->
+    <#-- II5 : Responsabilités (ETUII5) -->
     <#if ficheEvaluation.questionEtuII5>
+      <#assign etuii5Schema = (reponse.schemaVersion?? && reponse.schemaVersion gte 2) ? 2 : 1>
+      <#assign etuii5aOptions = etuii5Schema gte 2
+        ? ["Technique", "Organisationnelle", "Communication"]
+        : ["Très importantes", "Importantes", "Peu importantes"]>
       <div class="evaluation-item">
-        <p><strong>- ${questionEvaluations?filter(q -> q.code == "ETUII4")[0].texte}</strong>
-          <#if reponse.reponseEtuII5a??>
-            <#if reponse.reponseEtuII5a == 0>Tout à fait d'accord</#if>
-            <#if reponse.reponseEtuII5a == 1>Plutôt d'accord</#if>
-            <#if reponse.reponseEtuII5a == 2>Plutôt pas d'accord</#if>
-            <#if reponse.reponseEtuII5a == 3>Pas du tout d'accord</#if>
+        <p><strong>- ${questionEvaluations?filter(q -> q.code == "ETUII5")[0].texte}</strong>
+          <#if reponse.reponseEtuII5??>
+            <#if reponse.reponseEtuII5 == true>Oui</#if>
+            <#if reponse.reponseEtuII5 == false>Non</#if>
           </#if>
         </p>
-        <#if reponse.reponseEtuII5b??>
-          <p>• Précision :
-            <#if reponse.reponseEtuII5b == true>Oui</#if>
-            <#if reponse.reponseEtuII5b == false>Non</#if>
-          </p>
+        <#if reponse.reponseEtuII5?? && reponse.reponseEtuII5 == true>
+          <#if reponse.reponseEtuII5a??>
+            <p>Si oui, de quel ordre ?
+              <#if reponse.reponseEtuII5a gte 0 && reponse.reponseEtuII5a < etuii5aOptions?size>${etuii5aOptions[reponse.reponseEtuII5a]}</#if>
+            </p>
+          </#if>
+          <#if reponse.reponseEtuII5b??>
+            <p>Avec autonomie ?
+              <#if reponse.reponseEtuII5b == true>Oui</#if>
+              <#if reponse.reponseEtuII5b == false>Non</#if>
+            </p>
+          </#if>
         </#if>
       </div>
     </#if>
 
-    <#-- II6 : Responsabilités -->
+    <#-- II6 : Dimension internationale (ETUII6) -->
     <#if ficheEvaluation.questionEtuII6>
       <div class="evaluation-item">
-        <p><strong>- ${questionEvaluations?filter(q -> q.code == "ETUII5")[0].texte}</strong>
+        <p><strong>- ${questionEvaluations?filter(q -> q.code == "ETUII6")[0].texte}</strong>
           <#if reponse.reponseEtuII6??>
             <#if reponse.reponseEtuII6 == true>Oui</#if>
             <#if reponse.reponseEtuII6 == false>Non</#if>

--- a/src/test/java/org/esup_portail/esup_stage/controller/ConventionControllerValidationTest.java
+++ b/src/test/java/org/esup_portail/esup_stage/controller/ConventionControllerValidationTest.java
@@ -1,0 +1,68 @@
+package org.esup_portail.esup_stage.controller;
+
+import org.esup_portail.esup_stage.exception.AppException;
+import org.esup_portail.esup_stage.model.Convention;
+import org.esup_portail.esup_stage.model.Role;
+import org.esup_portail.esup_stage.model.Utilisateur;
+import org.esup_portail.esup_stage.repository.ConventionJpaRepository;
+import org.esup_portail.esup_stage.repository.PeriodeStageJpaRepository;
+import org.esup_portail.esup_stage.security.userdetails.CasUserDetailsImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConventionControllerValidationTest {
+
+    @InjectMocks
+    ConventionController conventionController;
+
+    @Mock
+    ConventionJpaRepository conventionJpaRepository;
+
+    @Mock
+    PeriodeStageJpaRepository periodeStageJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void validationCreation_rejectsIrregularHoursWithoutPeriods() {
+        Convention convention = new Convention();
+        convention.setId(1);
+        convention.setHorairesReguliers(false);
+
+        Utilisateur utilisateur = new Utilisateur();
+        Role role = new Role();
+        role.setCode(Role.GES);
+        utilisateur.setRoles(List.of(role));
+
+        CasUserDetailsImpl userDetails = new CasUserDetailsImpl(utilisateur, List.of());
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, null, List.of())
+        );
+
+        when(conventionJpaRepository.findById(1)).thenReturn(convention);
+        when(periodeStageJpaRepository.findByConvention(convention)).thenReturn(Collections.emptyList());
+
+        AppException exception = assertThrows(AppException.class, () -> conventionController.validationCreation(1));
+
+        assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(exception.getMessage()).contains("période de travail");
+    }
+}


### PR DESCRIPTION
Évaluations — issues #709 / #710

- Validation de l'évaluation étudiant alignée sur les seuls champs visibles
- Déblocage de la saisie ETUI7 en mode legacy + export « bis »
- Ajout d'un filtre Étape sur la liste des évaluations
- Correctifs retour client sur l'export et ETUI7


Convention — encart Sirene (issue #706)

- Restauration de l'encart d'information Sirene à la création de convention
- Unification des encarts Sirene et affichage conditionnel côté étudiant

Corrections ciblées

- #644 — Réinitialisation du choix d'élément pédagogique
- #690 — Restauration du filtre « Toutes les années » au retour sur le tableau de bord
- #708 — Correction de la validation des périodes de travail (onglet Stage, horaires irréguliers)